### PR TITLE
change prgenv-gnu view to only include roots

### DIFF
--- a/recipes/prgenv-gnu/23.11/mc/environments.yaml
+++ b/recipes/prgenv-gnu/23.11/mc/environments.yaml
@@ -14,9 +14,9 @@ gcc-env:
   - ninja@1.11
   - openblas
   - python@3.11
-  - py-pybind11
   - osu-micro-benchmarks@5.9
   variants:
   - +mpi
   views:
     default:
+      link: roots


### PR DESCRIPTION
Testing whether we can create environment views that can be used with `LD_LIBRARY_FLAGS` without conflicts.