### PR TITLE
Update Stackinator version

### DIFF
--- a/scripts/setup-stackinator
+++ b/scripts/setup-stackinator
@@ -5,7 +5,7 @@ tool_base_path="$(pwd)"
 # builds in the same pipeline do not conflict
 tool_path=`mktemp -d`
 tool_repo=https://github.com/eth-cscs/stackinator.git
-tool_version=d9f0026c9884a0685296ec06aaadf1ce8f6541b2
+tool_version=9cc2c9e8b8ea9b04611391b13f7a9da2ff849cf7
 
 log "installing stackinator from git in '${tool_path}'"
 


### PR DESCRIPTION
It should fix build failures in #67 (different SHA for `cray-mpich` introduced in https://github.com/eth-cscs/stackinator/pull/158).