### PR TITLE
Paraview for ICON on Santis

### DIFF
--- a/recipes/paraview/v1/gh200/compilers.yaml
+++ b/recipes/paraview/v1/gh200/compilers.yaml
@@ -1,0 +1,9 @@
+bootstrap:
+  spec: gcc@12.3
+gcc:
+  specs:
+  - gcc@12.3
+llvm:
+  requires: gcc@12.3
+  specs:
+  - nvhpc@24.3

--- a/recipes/paraview/v1/gh200/config.yaml
+++ b/recipes/paraview/v1/gh200/config.yaml
@@ -1,0 +1,6 @@
+name: icon-wcp
+store: /user-environment
+spack:
+  commit: releases/v0.21
+  repo: https://github.com/spack/spack.git
+description: The tools required to build ICON

--- a/recipes/paraview/v1/gh200/config.yaml
+++ b/recipes/paraview/v1/gh200/config.yaml
@@ -1,6 +1,6 @@
-name: icon-wcp
+name: paraview-icon
 store: /user-environment
 spack:
   commit: releases/v0.21
   repo: https://github.com/spack/spack.git
-description: The tools required to build ICON
+description: Paraview and the tools required to build ICON

--- a/recipes/paraview/v1/gh200/environments.yaml
+++ b/recipes/paraview/v1/gh200/environments.yaml
@@ -48,7 +48,7 @@ nvidia:
   - jasper%gcc
   - patchelf%gcc
   - gmake%gcc
-  - paraview@5.12%gcc +mpi +tbb +egl ~qt +fortran +python +hdf5 +nvindex
+  - paraview@5.12%gcc +mpi +tbb +egl ~qt +fortran +python +hdf5 +nvindex +cdi
   variants:
   - cuda_arch=90
   - +mpi

--- a/recipes/paraview/v1/gh200/environments.yaml
+++ b/recipes/paraview/v1/gh200/environments.yaml
@@ -48,7 +48,7 @@ nvidia:
   - jasper%gcc
   - patchelf%gcc
   - gmake%gcc
-  - paraview@5.12%gcc +mpi +tbb +egl ~qt +fortran +python +hdf5 +nvindex +cdi
+  - paraview@5.12%gcc +mpi +tbb +egl ~qt +fortran +python +hdf5 +nvindex +cdi +raytracing
   variants:
   - cuda_arch=90
   - +mpi

--- a/recipes/paraview/v1/gh200/environments.yaml
+++ b/recipes/paraview/v1/gh200/environments.yaml
@@ -48,8 +48,9 @@ nvidia:
   - jasper%gcc
   - patchelf%gcc
   - gmake%gcc
-  - paraview@5.12%gcc +mpi +tbb +egl ~qt +fortran +python +hdf5 +nvindex +cdi +raytracing
+  - paraview@5.12%gcc +mpi +tbb +egl ~qt +fortran +python +hdf5 +nvindex +cdi +raytracing +libcatalyst
   - llvm~cuda
+  - libcatalyst +fortran +python +mpi
   variants:
   - cuda_arch=90
   - +mpi

--- a/recipes/paraview/v1/gh200/environments.yaml
+++ b/recipes/paraview/v1/gh200/environments.yaml
@@ -48,6 +48,7 @@ nvidia:
   - jasper%gcc
   - patchelf%gcc
   - gmake%gcc
+  - paraview@5.12%gcc +mpi +tbb +egl ~qt +fortran +python +hdf5 +nvindex
   variants:
   - cuda_arch=90
   - +mpi

--- a/recipes/paraview/v1/gh200/environments.yaml
+++ b/recipes/paraview/v1/gh200/environments.yaml
@@ -49,6 +49,7 @@ nvidia:
   - patchelf%gcc
   - gmake%gcc
   - paraview@5.12%gcc +mpi +tbb +egl ~qt +fortran +python +hdf5 +nvindex +cdi +raytracing
+  - llvm~cuda
   variants:
   - cuda_arch=90
   - +mpi

--- a/recipes/paraview/v1/gh200/environments.yaml
+++ b/recipes/paraview/v1/gh200/environments.yaml
@@ -60,4 +60,4 @@ nvidia:
   - gmake
   views:
     default:
-      link: roots
+      link: run

--- a/recipes/paraview/v1/gh200/environments.yaml
+++ b/recipes/paraview/v1/gh200/environments.yaml
@@ -1,0 +1,60 @@
+nvidia:
+  compiler:
+      - toolchain: gcc
+        spec: gcc
+      - toolchain: llvm
+        spec: nvhpc
+  unify: when_possible
+  mpi:
+      spec: cray-mpich@8.1.29%nvhpc
+      gpu: cuda
+  specs:
+  - boost%gcc ~mpi
+  - python@3.10%gcc
+  #- eccodes@2.25.0%nvhpc +tools +fortran +aec +openmp jp2k=jasper
+  - cmake%gcc
+  - cuda@12.3%gcc
+  - hdf5%gcc
+  - hwloc%gcc
+  - netcdf-c%gcc
+  - netcdf-cxx4%gcc
+  - netcdf-fortran%nvhpc
+  - numactl%gcc
+  - osu-micro-benchmarks@5.9%nvhpc
+  # everything needed for nccl on SS11
+  - aws-ofi-nccl@master%gcc
+  - nccl%gcc
+  - nccl-tests%gcc
+  # The following are required to stop spack from using nvhpc to build
+  # basic dependencies, some of which don't compile with nvc etc.
+  # Explicitly excluded as modules.
+  - autoconf%gcc
+  - automake%gcc
+  - ca-certificates-mozilla%gcc
+  - diffutils%gcc
+  - gnuconfig%gcc
+  - libiconv%gcc
+  - libxcrypt%gcc
+  - libxml2%gcc
+  - m4%gcc
+  - ncurses%gcc
+  - openssl%gcc
+  - perl%gcc
+  - xz%gcc
+  - zlib%gcc
+  - zstd%gcc
+  - c-blosc%gcc
+  - libaec%gcc
+  - jasper%gcc
+  - patchelf%gcc
+  - gmake%gcc
+  variants:
+  - cuda_arch=90
+  - +mpi
+  - +cuda
+  packages:
+  - curl
+  - gmake
+  views:
+    default:
+      link: roots

--- a/recipes/paraview/v1/gh200/extra/reframe.yaml
+++ b/recipes/paraview/v1/gh200/extra/reframe.yaml
@@ -1,0 +1,6 @@
+default:
+  features: [osu-micro-benchmarks, mpi, serial, openmp]
+  cc: mpicc
+  cxx: mpic++
+  ftn: mpifort
+  activation: /user-environment/env/default/activate.sh

--- a/recipes/paraview/v1/gh200/modules.yaml
+++ b/recipes/paraview/v1/gh200/modules.yaml
@@ -1,0 +1,43 @@
+modules:
+  # Paths to check when creating modules for all module sets
+  prefix_inspections:
+    bin:
+      - PATH
+    lib:
+      - LD_LIBRARY_PATH
+    lib64:
+      - LD_LIBRARY_PATH
+
+  default:
+    arch_folder: false
+    # Where to install modules
+    roots:
+      tcl: /snap/modules
+    tcl:
+      all:
+        autoload: none
+      hash_length: 0
+      exclude_implicits: true
+      exclude:
+        - '%gcc@7.5.0'
+        - 'gcc %gcc@7.5.0'
+        - 'autoconf'
+        - 'automake'
+        - 'c-blosc'
+        - 'ca-certificates-mozilla'
+        - 'diffutils'
+        - 'gnuconfig'
+        - 'jasper'
+        - 'libaec'
+        - 'libiconv'
+        - 'libxcrypt'
+        - 'libxml2'
+        - 'patchelf'
+        - 'm4'
+        - 'ncurses'
+        - 'openssl'
+        - 'xz'
+        - 'zlib'
+        - 'zstd'
+      projections:
+        all: '{name}/{version}'

--- a/recipes/paraview/v1/gh200/repo/packages/cdi/package.py
+++ b/recipes/paraview/v1/gh200/repo/packages/cdi/package.py
@@ -1,0 +1,50 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install cdi
+#
+# You can edit this file again by typing:
+#
+#     spack edit cdi
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+
+from spack.package import *
+
+
+class Cdi(AutotoolsPackage):
+    """
+    CDI is a C and Fortran Interface to access Climate and NWP model Data.
+    Supported data formats are GRIB, netCDF, SERVICE, EXTRA and IEG.
+    """
+
+    homepage = "https://code.mpimet.mpg.de/projects/cdi"
+    url = "https://code.mpimet.mpg.de/attachments/download/29309/cdi-2.4.0.tar.gz"
+
+    # FIXME: Add the SPDX identifier of the project's license below.
+    # See https://spdx.org/licenses/ for a list. Upon manually verifying
+    # the license, set checked_by to your Github username.
+    # license("UNKNOWN", checked_by="github_user1")
+
+    version("2.4.0", sha256="91fca015b04c6841b9eab8b49e7726d35e35b9ec4350922072ec6e9d5eb174ef")
+
+    variant("netcdf", default=True, description="This is needed to read/write NetCDF files with CDI")
+
+    depends_on("netcdf-c", when="+netcdf")
+
+    def configure_args(self):
+        args = []
+        if "+netcdf" in self.spec:
+            args.append("--with-netcdf=" + self.spec["netcdf-c"].prefix)
+        return args

--- a/recipes/paraview/v1/gh200/repo/packages/egl/package.py
+++ b/recipes/paraview/v1/gh200/repo/packages/egl/package.py
@@ -1,0 +1,92 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import re
+import sys
+
+from spack.package import *
+
+
+class Egl(BundlePackage):
+    """Placeholder for external EGL(OpenGL) libraries from hardware vendors"""
+
+    homepage = "https://www.khronos.org/egl"
+    maintainers("biddisco")
+
+    version("1.5")
+
+    # This should really be when='platform=linux' but can't because of a
+    # current bug in when and how ArchSpecs are constructed
+    if sys.platform.startswith("linux"):
+        provides("gl@4.5")
+
+    # conflict with GLX
+    conflicts("glx")
+
+    # not always available, but sometimes
+    executables = ["^eglinfo$"]
+
+    @classmethod
+    def determine_version(cls, exe):
+        if exe:
+            output = Executable(exe)(output=str, error=str)
+            match = re.search(r"EGL version string: (\S+)", output)
+            return match.group(1) if match else None
+        else:
+            return None
+
+    # Override the fetcher method to throw a useful error message;
+    # fixes GitHub issue (#7061) in which this package threw a
+    # generic, uninformative error during the `fetch` step,
+    @property
+    def fetcher(self):
+        msg = """This package is intended to be a placeholder for
+        system-provided EGL(OpenGL) libraries from hardware vendors.  Please
+        download and install EGL drivers/libraries for your graphics
+        hardware separately, and then set that up as an external package.
+        An example of a working packages.yaml:
+
+        packages:
+          egl:
+            buildable: False
+            externals:
+            - spec: egl@1.5.0
+              prefix: /usr/
+
+        In that case, /usr/ should contain these two folders:
+
+        include/EGL/      (egl headers, including "egl.h")
+        lib               (egl libraries, including "libEGL.so")
+
+        """
+        raise InstallError(msg)
+
+    @fetcher.setter  # Since fetcher is read-write, must override both
+    def fetcher(self):
+        _ = self.fetcher
+
+    @property
+    def headers(self):
+        return self.egl_headers
+
+    @property
+    def libs(self):
+        return self.egl_libs
+
+    @property
+    def egl_headers(self):
+        header_name = "GL/gl"
+        gl_header = find_headers(header_name, root=self.prefix, recursive=True)
+        header_name = "EGL/egl"
+        egl_header = find_headers(header_name, root=self.prefix, recursive=True)
+        return gl_header + egl_header
+
+    @property
+    def egl_libs(self):
+        lib_name = "libGL"
+        gl_lib = find_libraries(lib_name, root=self.prefix, recursive=True)
+        lib_name = "libEGL"
+        egl_lib = find_libraries(lib_name, root=self.prefix, recursive=True)
+        return gl_lib + egl_lib

--- a/recipes/paraview/v1/gh200/repo/packages/glew/package.py
+++ b/recipes/paraview/v1/gh200/repo/packages/glew/package.py
@@ -1,0 +1,79 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import sys
+
+from spack.package import *
+
+
+class Glew(CMakePackage):
+    """The OpenGL Extension Wrangler Library."""
+
+    homepage = "http://glew.sourceforge.net/"
+    url = "https://github.com/nigels-com/glew/releases/download/glew-2.1.0/glew-2.1.0.tgz"
+    root_cmakelists_dir = "build/cmake"
+
+    maintainers("biddisco")
+
+    license("GPL-2.0-or-later")
+
+    version("2.2.0", sha256="d4fc82893cfb00109578d0a1a2337fb8ca335b3ceccf97b97e5cc7f08e4353e1")
+    version("2.1.0", sha256="04de91e7e6763039bc11940095cd9c7f880baba82196a7765f727ac05a993c95")
+    version("2.0.0", sha256="c572c30a4e64689c342ba1624130ac98936d7af90c3103f9ce12b8a0c5736764")
+
+    variant(
+        "gl",
+        default="glx" if sys.platform.startswith("linux") else "other",
+        values=("glx", "osmesa", "egl", "other"),
+        multi=False,
+        description="The OpenGL provider to use",
+    )
+    conflicts("^osmesa", when="gl=glx")
+    conflicts("^osmesa", when="gl=egl")
+    conflicts("^osmesa", when="gl=other")
+    conflicts("^glx", when="gl=osmesa")
+    conflicts("^glx", when="gl=other")
+    conflicts("^glx", when="gl=egl")
+    conflicts("^egl", when="gl=glx")
+    conflicts("^egl", when="gl=osmesa")
+    conflicts("^egl", when="gl=other")
+
+    depends_on("gl")
+    depends_on("osmesa", when="gl=osmesa")
+    depends_on("glx", when="gl=glx")
+    depends_on("libx11", when="gl=glx")
+    depends_on("xproto", when="gl=glx")
+    depends_on("egl", when="gl=egl")
+
+    # glu is already forcibly disabled in the CMakeLists.txt.  This prevents
+    # it from showing up in the .pc file
+    patch("remove-pkgconfig-glu-dep.patch")
+
+    def cmake_args(self):
+        spec = self.spec
+        args = [
+            self.define("BUILD_UTILS", True),
+            self.define("GLEW_REGAL", False),
+            self.define("GLEW_EGL", "gl=egl" in spec),
+            self.define("OPENGL_INCLUDE_DIR", spec["gl"].headers.directories[0]),
+            self.define("OPENGL_gl_LIBRARY", spec["gl"].libs[0]),
+            self.define("OPENGL_opengl_LIBRARY", "IGNORE"),
+            self.define("OPENGL_glx_LIBRARY", "IGNORE"),
+            self.define("OPENGL_glu_LIBRARY", "IGNORE"),
+            self.define("GLEW_OSMESA", "gl=osmesa" in spec),
+        ]
+        if "gl=egl" in spec:
+            args.append(
+                self.define("OPENGL_egl_LIBRARY", [spec["egl"].libs[0], spec["egl"].libs[1]])
+            )
+        else:
+            args.append(self.define("OPENGL_egl_LIBRARY", "IGNORE"))
+
+        return args
+
+    def flag_handler(self, name, flags):
+        if name == "ldflags" and self.spec.satisfies("platform=darwin ^apple-gl"):
+            flags.append("-framework OpenGL")
+        return (flags, None, None)

--- a/recipes/paraview/v1/gh200/repo/packages/glew/remove-pkgconfig-glu-dep.patch
+++ b/recipes/paraview/v1/gh200/repo/packages/glew/remove-pkgconfig-glu-dep.patch
@@ -1,0 +1,18 @@
+diff --git a/build/cmake/CMakeLists.txt b/build/cmake/CMakeLists.txt
+index 419c243..339617f 100644
+--- a/build/cmake/CMakeLists.txt
++++ b/build/cmake/CMakeLists.txt
+@@ -215,12 +215,7 @@ set (includedir ${CMAKE_INSTALL_FULL_INCLUDEDIR})
+ set (version ${GLEW_VERSION})
+ set (libname ${GLEW_LIB_NAME})
+ set (cflags)
+-set (requireslib glu)
+-
+-#  Mac OSX has no glu.pc unless optional X11/GLX is installed
+-if (APPLE)
+-  set (requireslib)
+-endif ()
++set (requireslib)
+ 
+ configure_file (${GLEW_DIR}/glew.pc.in ${CMAKE_CURRENT_BINARY_DIR}/glew.pc @ONLY)
+ 

--- a/recipes/paraview/v1/gh200/repo/packages/ispc/don-t-assume-that-ncurses-zlib-are-system-libraries.patch
+++ b/recipes/paraview/v1/gh200/repo/packages/ispc/don-t-assume-that-ncurses-zlib-are-system-libraries.patch
@@ -1,0 +1,28 @@
+From 44250379632ace94b08ff2dba17c69d3f36d5ffb Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Aumu=CC=88ller?= <aumuell@reserv.at>
+Date: Sun, 27 Sep 2020 20:23:42 +0200
+Subject: [PATCH] don't assume that ncurses & zlib are system libraries
+
+---
+ CMakeLists.txt | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2bb4a7e6..53239a88 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -473,7 +473,10 @@ else()
+         if (ISPC_STATIC_LINK)
+             target_link_libraries(${PROJECT_NAME} pthread z.a tinfo.a curses.a)
+         else()
+-            target_link_libraries(${PROJECT_NAME} pthread z tinfo curses)
++            find_package(Curses REQUIRED)
++            find_package(ZLIB REQUIRED)
++            find_library(NCURSES_TINFO_LIBRARY tinfo)
++            target_link_libraries(${PROJECT_NAME} pthread ${ZLIB_LIBRARIES} ${NCURSES_TINFO_LIBRARY} ${CURSES_LIBRARIES})
+         endif()
+     endif()
+ endif()
+-- 
+2.29.0
+

--- a/recipes/paraview/v1/gh200/repo/packages/ispc/fix-linking-against-llvm-10.patch
+++ b/recipes/paraview/v1/gh200/repo/packages/ispc/fix-linking-against-llvm-10.patch
@@ -1,0 +1,26 @@
+From 0b68b43ec71130e1167d9ff59d5f874be47a9414 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Aumu=CC=88ller?= <aumuell@reserv.at>
+Date: Sun, 18 Oct 2020 21:02:32 +0200
+Subject: [PATCH] fix linking against llvm 10
+
+---
+ CMakeLists.txt | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 68759c14..f4499c8f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -401,6 +401,9 @@ target_link_libraries(${PROJECT_NAME} ${LLVM_LIBRARY_LIST})
+ if (WIN32)
+     target_link_libraries(${PROJECT_NAME} version.lib shlwapi.lib odbc32.lib odbccp32.lib)
+ else()
++    if (CMAKE_DL_LIBS)
++        target_link_libraries(${PROJECT_NAME} ${CMAKE_DL_LIBS})
++    endif()
+     if (APPLE)
+         target_link_libraries(${PROJECT_NAME} pthread z curses)
+     else()
+-- 
+2.28.0
+

--- a/recipes/paraview/v1/gh200/repo/packages/ispc/package.py
+++ b/recipes/paraview/v1/gh200/repo/packages/ispc/package.py
@@ -1,0 +1,128 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+import re
+
+from spack.package import *
+
+# ispc requires <gnu/stubs-32.h>, e.g. from
+# glibc-devel.i686 (CentoOS) or libc6-dev-i386 and g++-multilib (Ubuntu)
+
+
+class Ispc(CMakePackage):
+    """Intel Implicit SPMD Program Compiler
+
+    An open-source compiler for high-performance SIMD programming on the CPU"""
+
+    homepage = "https://ispc.github.io"
+    url = "https://github.com/ispc/ispc/tarball/v1.14.1"
+    git = "https://github.com/ispc/ispc"
+    maintainers("aumuell")
+
+    executables = ["^ispc$"]
+
+    license("BSD-3-Clause")
+
+    version("main", branch="main")
+    version("1.23.0", sha256="e268eabed9a9021b4402725ed1c120b8eca776ee4aaf50ddeb0e4adaadda05f9")
+    version("1.22.0", sha256="1f115eeed7df5028c19c9b256887949ca88c29c146f641b031d8e080297f5acd")
+    version("1.21.1", sha256="99bbb1d1f15bc4433d6a63b5bb35b321af3e3af753c3b28a61850d1748e8a89f")
+    version("1.21.0", sha256="023782f721bfb5893bac24bc2153a8214c916be82c290bf63a3ec6678949b5ef")
+    version("1.20.0", sha256="8bd30ded7f96859451ead1cecf6f58ac8e937288fe0e5b98c56f6eba4be370b4")
+    version("1.19.0", sha256="c1aeae4bdfb28004a6949394ea1b3daa3fdf12f646e17fcc0614861077dc8b6a")
+    version("1.18.1", sha256="fee76d42fc0129f81489b7c2b9143e22a44c281940693c1c13cf1e3dd2ab207f")
+    version("1.18.0", sha256="ecf1fc6ad5e39242e555b8e0ac539489939a9e475722eaa9da5caa4651cecf05")
+    version("1.17.0", sha256="1d47365febd2e17c84c22501aa63b1eafbc1ef826d6f5deadafe14783b8388a5")
+    version("1.16.1", sha256="b32dbd374eea5f1b5f535bfd79c5cc35591c0df2e7bf1f86dec96b74e4ebf661")
+    version("1.16.0", sha256="12db1a90046b51752a65f50426e1d99051c6d55e30796ddd079f7bc97d5f6faf")
+    version("1.15.0", sha256="3b634aaa10c9bf0e82505d1af69cb307a3a00182d57eae019680ccfa62338af9")
+    version("1.14.1", sha256="ca12f26dafbc4ef9605487d03a2156331c1351a4ffefc9bab4d896a466880794")
+    version("1.14.0", sha256="1ed72542f56738c632bb02fb0dd56ad8aec3e2487839ebbc0def8334f305a4c7")
+    version("1.13.0", sha256="aca595508b51dd1ff065c406a3fd7c93822320c510077dd4d97a2b98a23f097a")
+
+    depends_on("python", type="build")
+    depends_on("bison", type="build")
+    depends_on("flex", type="build")
+    depends_on("ncurses", type="link")
+    depends_on("zlib-api", type="link")
+    depends_on("tbb", type="link", when="platform=linux @1.20:")
+    depends_on("llvm+clang", type="build")
+    depends_on("llvm libcxx=none", when="platform=darwin", type="build")
+    depends_on("llvm targets=arm,aarch64", when="target=arm:", type="build")
+    depends_on("llvm targets=arm,aarch64", when="target=aarch64:", type="build")
+    depends_on("llvm@:17", when="@:1.23", type="build")
+    depends_on("llvm@:15", when="@:1.20", type="build")
+    depends_on("llvm@:14", when="@:1.18", type="build")
+    depends_on("llvm@:12", when="@:1.16", type="build")
+    depends_on("llvm@:11", when="@:1.15", type="build")
+    depends_on("llvm@:10", when="@:1.14", type="build")
+    depends_on("llvm@13:", when="@1.19:", type="build")
+    depends_on("llvm@11:", when="@1.16:", type="build")
+    depends_on("llvm@10:", when="@1.13:", type="build")
+
+    patch(
+        "don-t-assume-that-ncurses-zlib-are-system-libraries.patch",
+        when="@1.14.0:1.14",
+        sha256="d3ccf547d3ba59779fd375e10417a436318f2200d160febb9f830a26f0daefdc",
+    )
+
+    patch(
+        "fix-linking-against-llvm-10.patch",
+        when="@1.13.0:1.13",
+        sha256="d3ccf547d3ba59779fd375e10417a436318f2200d160febb9f830a26f0daefdc",
+    )
+
+    # Fix build with Apple clang 15
+    patch(
+        "https://github.com/ispc/ispc/pull/2785.patch?full_index=1",
+        when="@1.22:1.23.0",
+        sha256="f6a413bf86e49d520d23df7132004d1f09caa512187f369549a4a783859fbc41",
+    )
+
+    # Fix library lookup for NCurses in CMake
+    patch(
+        "https://patch-diff.githubusercontent.com/raw/ispc/ispc/pull/2638.patch?full_index=1",
+        when="@1.18:1.20",
+        sha256="3f7dae8d4a683fca2a6157bbcb7cbe9692ff2094b0f4afaf29be121c02b0b3ad",
+    )
+
+    def setup_build_environment(self, env):
+        if self.spec.satisfies("@1.18.0:"):
+            env.append_flags("LDFLAGS", "-lz")
+
+    def patch(self):
+        with open("check-m32.c", "w") as f:
+            f.write("#include <sys/cdefs.h>")
+        try:
+            Executable(self.compiler.cc)("-m32", "-shared", "check-m32.c", error=str)
+        except ProcessError:
+            filter_file("bit 32 64", "bit 64", "cmake/GenerateBuiltins.cmake")
+
+    def cmake_args(self):
+        spec = self.spec
+        args = []
+        args.append("-DISPC_NO_DUMPS=ON")  # otherwise, LLVM needs patching
+        args.append("-DCURSES_NEED_NCURSES=TRUE")
+        args.append("-DISPC_INCLUDE_EXAMPLES=OFF")
+        args.append("-DISPC_INCLUDE_TESTS=OFF")
+        args.append("-DISPC_INCLUDE_UTILS=OFF")
+        if spec.satisfies("target=x86_64:") or spec.satisfies("target=x86:"):
+            args.append("-DARM_ENABLED=OFF")
+        elif spec.satisfies("target=aarch64:"):
+            args.append("-DARM_ENABLED=ON")
+        return args
+
+    @run_after("install")
+    def check_install(self):
+        with working_dir(self.stage.source_path):
+            ispc = Executable(join_path(self.prefix, "bin", "ispc"))
+            ispc("--version")
+
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)("--version", output=str, error=str)
+        match = re.search(r"^Intel.*[iI][sS][pP][cC]\),\s+(\S+)\s+\(build.*\)", output)
+        return match.group(1) if match else None

--- a/recipes/paraview/v1/gh200/repo/packages/libcatalyst/package.py
+++ b/recipes/paraview/v1/gh200/repo/packages/libcatalyst/package.py
@@ -1,0 +1,73 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import subprocess
+
+import llnl.util.tty as tty
+
+from spack.package import *
+
+
+class Libcatalyst(CMakePackage):
+    """Catalyst is an API specification developed for simulations (and other
+    scientific data producers) to analyze and visualize data in situ."""
+
+    homepage = "https://gitlab.kitware.com/paraview/catalyst"
+    git = "https://gitlab.kitware.com/paraview/catalyst.git"
+    url = "https://gitlab.kitware.com/api/v4/projects/5912/packages/generic/catalyst/v2.0.0/catalyst-v2.0.0.tar.gz"
+
+    license("BSD-3-Clause")
+
+    maintainers("mathstuf", "ayenpure")
+    version("master", branch="master")
+    version("2.0.0", sha256="5842b690bd8afa635414da9b9c5e5d79fa37879b0d382428d0d8e26ba5374828")
+
+    variant("mpi", default=False, description="Enable MPI support")
+    variant("conduit", default=False, description="Use external Conduit for Catalyst")
+    variant("fortran", default=False, description="Enable Fortran wrapping")
+    variant("python", default=False, description="Enable Python wrapping")
+
+    depends_on("mpi", when="+mpi")
+    depends_on("conduit", when="+conduit")
+    depends_on("cmake@3.26:", type="build")
+    depends_on("python", when="+python")
+    depends_on("py-numpy", when="+python")
+
+    def cmake_args(self):
+        """Populate cmake arguments for libcatalyst."""
+        args = [
+            "-DCATALYST_BUILD_TESTING=OFF",
+            self.define_from_variant("CATALYST_USE_MPI", "mpi"),
+            self.define_from_variant("CATALYST_WITH_EXTERNAL_CONDUIT", "conduit"),
+            self.define_from_variant("CATALYST_WRAP_FORTRAN", "fortran"),
+            self.define_from_variant("CATALYST_WRAP_PYTHON", "python"),
+        ]
+
+        return args
+
+    def setup_run_environment(self, env):
+        spec = self.spec
+        if spec.satisfies("+conduit"):
+            env.prepend_path("CMAKE_PREFIX_PATH", spec["conduit"].prefix)
+
+    @on_package_attributes(run_tests=True)
+    @run_after("install")
+    def build_test(self):
+        testdir = "smoke_test_build"
+        cmakeExampleDir = join_path(self.stage.source_path, "examples")
+        cmake_args = [
+            cmakeExampleDir,
+            "-DBUILD_SHARED_LIBS=ON",
+            self.define("CMAKE_PREFIX_PATH", self.prefix),
+        ]
+        cmake = which(self.spec["cmake"].prefix.bin.cmake)
+
+        with working_dir(testdir, create=True):
+            cmake(*cmake_args)
+            cmake(*(["--build", "."]))
+            tty.info("Running Catalyst test")
+
+            res = subprocess.run(["adaptor0/adaptor0_test", "catalyst"])
+            assert res.returncode == 0

--- a/recipes/paraview/v1/gh200/repo/packages/opengl/package.py
+++ b/recipes/paraview/v1/gh200/repo/packages/opengl/package.py
@@ -1,0 +1,111 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import re
+import sys
+
+from spack.package import *
+
+
+class Opengl(BundlePackage):
+    """Placeholder for external OpenGL libraries from hardware vendors"""
+
+    homepage = "https://www.opengl.org/"
+    version("4.5")
+    maintainers("biddisco")
+
+    # This should really be when='platform=linux' but can't because of a
+    # current bug in when and how ArchSpecs are constructed
+    if sys.platform.startswith("linux"):
+        provides("libglx")
+        executables = ["^glxinfo$"]
+    else:  # windows and mac
+        provides("gl@4.5")
+
+    @classmethod
+    def determine_version(cls, exe):
+        if exe:
+            output = Executable(exe)(output=str, error=str)
+            match = re.search(r"OpenGL version string: (\S+)", output)
+            return match.group(1) if match else None
+        else:
+            return None
+
+    # Override the fetcher method to throw a useful error message;
+    # fixes GitHub issue (#7061) in which this package threw a
+    # generic, uninformative error during the `fetch` step,
+    @property
+    def fetcher(self):
+        msg = """This package is intended to be a placeholder for
+        system-provided OpenGL libraries from hardware vendors.  Please
+        download and install OpenGL drivers/libraries for your graphics
+        hardware separately, and then set that up as an external package.
+        An example of a working packages.yaml:
+
+        packages:
+          opengl:
+            buildable: False
+            externals:
+            - spec: opengl@4.5.0
+              prefix: /opt/opengl
+
+        In that case, /opt/opengl/ should contain these two folders:
+
+        include/GL/       (opengl headers, including "gl.h")
+        lib               (opengl libraries, including "libGL.so")
+
+        On Apple Darwin (e.g., OS X, macOS) systems, this package is
+        normally installed as part of the XCode Command Line Tools in
+        /usr/X11R6, so a working packages.yaml would be
+
+        packages:
+          opengl:
+            buildable: False
+            externals:
+            - spec: opengl@4.1
+              prefix: /usr/X11R6
+
+        In that case, /usr/X11R6 should contain
+
+        include/GL/      (OpenGL headers, including "gl.h")
+        lib              (OpenGL libraries, including "libGL.dylib")
+
+        On OS X/macOS, note that the version of OpenGL provided
+        depends on your hardware. Look at
+        https://support.apple.com/en-us/HT202823 to see what version
+        of OpenGL your Mac uses."""
+        raise InstallError(msg)
+
+    @fetcher.setter  # Since fetcher is read-write, must override both
+    def fetcher(self):
+        _ = self.fetcher
+
+    @property
+    def headers(self):
+        return self.gl_headers
+
+    @property
+    def libs(self):
+        return self.gl_libs
+
+    @property
+    def gl_headers(self):
+        spec = self.spec
+        if "platform=darwin" in spec:
+            header_name = "OpenGL/gl"
+        else:
+            header_name = "GL/gl"
+        return find_headers(header_name, root=self.prefix, recursive=True)
+
+    @property
+    def gl_libs(self):
+        spec = self.spec
+        if "platform=windows" in spec:
+            lib_name = "opengl32"
+        elif "platform=darwin" in spec:
+            lib_name = "libOpenGL"
+        else:  # linux and cray
+            lib_name = "libGL"
+        return find_libraries(lib_name, root=self.prefix, recursive=True)

--- a/recipes/paraview/v1/gh200/repo/packages/openimagedenoise/package.py
+++ b/recipes/paraview/v1/gh200/repo/packages/openimagedenoise/package.py
@@ -1,0 +1,39 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Openimagedenoise(CMakePackage):
+    """Intel Open Image Denoise is an open source library of high-performance,
+    high-quality denoising filters for images rendered with ray tracing.
+    Open Image Denoise is part of the Intel® oneAPI Rendering Toolkit and is released
+    under the permissive Apache 2.0 license."""
+
+    homepage = "https://www.openimagedenoise.org/"
+    url = "https://github.com/OpenImageDenoise/oidn/releases/download/v1.4.3/oidn-1.4.3.src.tar.gz"
+
+    # maintainers("github_user1", "github_user2")
+
+    license("Apache-2.0")
+
+    version("2.2.2", sha256="d26b75fa216165086f65bf48c80648290f2cfed7d3c4bfc1e86c247b46c96b7e")
+    version("2.1.0", sha256="ce144ba582ff36563d9442ee07fa2a4d249bc85aa93e5b25fc527ff4ee755ed6")
+    version("2.0.1", sha256="328eeb9809d18e835dca7203224af3748578794784c026940c02eea09c695b90")
+    version("1.4.3", sha256="3276e252297ebad67a999298d8f0c30cfb221e166b166ae5c955d88b94ad062a")
+    version("1.4.2", sha256="e70d27ce24b41364782376c1b3b4f074f77310ccfe5f8ffec4a13a347e48a0ea")
+    version("1.4.1", sha256="9088966685a78adf24b8de075d66e4c0019bd7b2b9d29c6e45aaf35d294e3f6f")
+    version("1.4.0", sha256="3e7b85d344b3635719879c4444f061714e6e799895110bd5d78a357dc9b017db")
+    version("1.3.0", sha256="88367b2bbea82d1df45d65141c36b6d86491bc6b397dc70beb3a05dda566f31c")
+    version("1.2.4", sha256="948b070c780b5de0d983e7d5d37f6d9454932cc278913d9ee5b0bd047d23864a")
+    version("1.2.3", sha256="469d20b093a73b18a54a2e559b0f18a6baac845ede864be62429737042ebe4f7")
+
+    depends_on("ispc", type=("build"))
+    depends_on("python@3:", type=("build", "test"))
+    depends_on("tbb")
+
+    def cmake_args(self):
+        args = [self.define("OIDN_APPS", False)]
+        return args

--- a/recipes/paraview/v1/gh200/repo/packages/paraview/FindFreetype.cmake.patch
+++ b/recipes/paraview/v1/gh200/repo/packages/paraview/FindFreetype.cmake.patch
@@ -1,0 +1,38 @@
+Submodule VTK contains modified content
+diff --git a/VTK/CMake/FindFreetype.cmake b/VTK/CMake/FindFreetype.cmake
+index b4532735c2..51671d4c3c 100644
+--- a/VTK/CMake/FindFreetype.cmake
++++ b/VTK/CMake/FindFreetype.cmake
+@@ -63,6 +63,32 @@ directory of a Freetype installation.
+ # I'm going to attempt to cut out the middleman and hope
+ # everything still works.
+ 
++find_package(freetype CONFIG) # foward `QUIET`, version, and components here, but not `REQUIRED`
++if (freetype_FOUND)
++  if (NOT TARGET Freetype::Freetype)
++    # make target chain to target from config mode
++    get_target_property(freetype_library_type freetype TYPE)
++    get_target_property(freetype_location freetype LOCATION)
++    if (freetype_library_type STREQUAL STATIC_LIBRARY)
++      set(freetype_library_type STATIC)
++    elseif (freetype_library_type STREQUAL SHARED_LIBRARY)
++      set(freetype_library_type SHARED)
++    endif()
++    get_target_property(freetype_interface_include_directories freetype INTERFACE_INCLUDE_DIRECTORIES)
++    get_target_property(freetype_interface_link_libraries freetype INTERFACE_LINK_LIBRARIES)
++    add_library(Freetype::Freetype "${freetype_library_type}" IMPORTED)
++    set_target_properties(Freetype::Freetype PROPERTIES
++      INTERFACE_INCLUDE_DIRECTORIES "${freetype_interface_include_directories}"
++      INTERFACE_LINK_LIBRARIES "${freetype_interface_link_libraries}"
++      IMPORTED_LINK_INTERFACE_LANGUAGES_RELEASE "C"
++      IMPORTED_LOCATION "${freetype_location}")
++  endif ()
++  set(FREETYPE_INCLUDE_DIRS "${freetype_interface_include_directories}")
++  set(FREETYPE_LIBRARIES "${freetype_interface_link_libraries}")
++  set(Freetype_FOUND 1) # might need to also forward the version found
++  return ()
++endif ()
++
+ set(FREETYPE_FIND_ARGS
+   HINTS
+     ENV FREETYPE_DIR

--- a/recipes/paraview/v1/gh200/repo/packages/paraview/adios2-remove-deprecated-functions.patch
+++ b/recipes/paraview/v1/gh200/repo/packages/paraview/adios2-remove-deprecated-functions.patch
@@ -1,0 +1,31 @@
+From fdb93d3e9d447b9dd6ce5c77aca18396cf9b6aa3 Mon Sep 17 00:00:00 2001
+From: Vicente Bolea <vicente.bolea@kitware.com>
+Date: Mon, 3 Apr 2023 12:58:58 -0400
+Subject: [PATCH] Update /VTK/IO/ADIOS2/vtkADIOS2CoreImageReader.cxx
+
+---
+ VTK/IO/ADIOS2/vtkADIOS2CoreImageReader.cxx | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/VTK/IO/ADIOS2/vtkADIOS2CoreImageReader.cxx b/VTK/IO/ADIOS2/vtkADIOS2CoreImageReader.cxx
+index 5d58905a88..3ce039345a 100644
+--- a/VTK/IO/ADIOS2/vtkADIOS2CoreImageReader.cxx
++++ b/VTK/IO/ADIOS2/vtkADIOS2CoreImageReader.cxx
+@@ -361,12 +361,12 @@ bool vtkADIOS2CoreImageReader::OpenAndReadMetaData()
+     vtkMPICommunicator* comm =
+       static_cast<vtkMPICommunicator*>(this->Controller->GetCommunicator());
+ 
+-    this->Impl->Adios.reset(new adios2::ADIOS(*comm->GetMPIComm()->GetHandle(), adios2::DebugON));
++    this->Impl->Adios.reset(new adios2::ADIOS(*comm->GetMPIComm()->GetHandle()));
+ #else
+     // Make sure the ADIOS subsystem is initialized before processing any
+     // sort of request.
+ 
+-    this->Impl->Adios.reset(new adios2::ADIOS(adios2::DebugON));
++    this->Impl->Adios.reset(new adios2::ADIOS());
+     // Before processing any request, read the meta data first
+ #endif
+   }
+-- 
+2.35.3
+

--- a/recipes/paraview/v1/gh200/repo/packages/paraview/catalyst-etc_oneapi_fix.patch
+++ b/recipes/paraview/v1/gh200/repo/packages/paraview/catalyst-etc_oneapi_fix.patch
@@ -1,0 +1,45 @@
+diff --git a/ThirdParty/catalyst/vtkcatalyst/catalyst/thirdparty/conduit/fmt/conduit_fmt/format.h b/ThirdParty/catalyst/vtkcatalyst/catalyst/thirdparty/conduit/fmt/conduit_fmt/format.h
+index f0902169..86eb72e7 100644
+--- a/ThirdParty/catalyst/vtkcatalyst/catalyst/thirdparty/conduit/fmt/conduit_fmt/format.h
++++ b/ThirdParty/catalyst/vtkcatalyst/catalyst/thirdparty/conduit/fmt/conduit_fmt/format.h
+@@ -1726,7 +1726,7 @@ OutputIt write_nonfinite(OutputIt out, bool isinf,
+   auto str =
+       isinf ? (fspecs.upper ? "INF" : "inf") : (fspecs.upper ? "NAN" : "nan");
+   constexpr size_t str_size = 3;
+-  auto sign = fspecs.sign;
++  auto sign = static_cast<unsigned int>(fspecs.sign);
+   auto size = str_size + (sign ? 1 : 0);
+   using iterator = remove_reference_t<decltype(reserve(out, 0))>;
+   return write_padded(out, specs, size, [=](iterator it) {
+@@ -1807,7 +1807,7 @@ OutputIt write_float(OutputIt out, const DecimalFP& fp,
+   auto significand = fp.significand;
+   int significand_size = get_significand_size(fp);
+   static const Char zero = static_cast<Char>('0');
+-  auto sign = fspecs.sign;
++  auto sign = static_cast<unsigned int>(fspecs.sign);
+   size_t size = to_unsigned(significand_size) + (sign ? 1 : 0);
+   using iterator = remove_reference_t<decltype(reserve(out, 0))>;
+ 
+
+diff --git a/VTK/ThirdParty/fmt/vtkfmt/vtkfmt/format.h b/VTK/ThirdParty/fmt/vtkfmt/vtkfmt/format.h
+index 5398a23a..108b4f90 100644
+--- a/VTK/ThirdParty/fmt/vtkfmt/vtkfmt/format.h
++++ b/VTK/ThirdParty/fmt/vtkfmt/vtkfmt/format.h
+@@ -1587,7 +1587,7 @@ auto write_nonfinite(OutputIt out, bool isinf, basic_format_specs<Char> specs,
+   auto str =
+       isinf ? (fspecs.upper ? "INF" : "inf") : (fspecs.upper ? "NAN" : "nan");
+   constexpr size_t str_size = 3;
+-  auto sign = fspecs.sign;
++  auto sign = static_cast<unsigned int>(fspecs.sign);
+   auto size = str_size + (sign ? 1 : 0);
+   // Replace '0'-padding with space for non-finite values.
+   const bool is_zero_fill =
+@@ -1673,7 +1673,7 @@ auto write_float(OutputIt out, const DecimalFP& fp,
+   auto significand = fp.significand;
+   int significand_size = get_significand_size(fp);
+   static const Char zero = static_cast<Char>('0');
+-  auto sign = fspecs.sign;
++  auto sign = static_cast<unsigned int>(fspecs.sign);
+   size_t size = to_unsigned(significand_size) + (sign ? 1 : 0);
+   using iterator = reserve_iterator<OutputIt>;
+ 

--- a/recipes/paraview/v1/gh200/repo/packages/paraview/exodusII-netcdf4.9.0.patch
+++ b/recipes/paraview/v1/gh200/repo/packages/paraview/exodusII-netcdf4.9.0.patch
@@ -1,0 +1,14 @@
+*** a/VTK/ThirdParty/exodusII/vtkexodusII/src/ex_utils.c	2023-03-16 16:57:14.172102586 -0400
+--- b/VTK/ThirdParty/exodusII/vtkexodusII/src/ex_utils.c	2023-03-16 11:20:28.230116660 -0400
+***************
+*** 1770,1776 ****
+--- 1770,1778 ----
+          */
+  
+          /* const int NC_SZIP_EC = 4; */ /* Selects entropy coding method for szip. */
++ #ifndef NC_SZIP_NN
+          const int NC_SZIP_NN = 32;      /* Selects nearest neighbor coding method for szip. */
++ #endif
+          /* Even and between 4 and 32; typical values are 8, 10, 16, 32 */
+          const int SZIP_PIXELS_PER_BLOCK =
+              file->compression_level == 0 ? 32 : file->compression_level;

--- a/recipes/paraview/v1/gh200/repo/packages/paraview/gcc-compiler-pv501.patch
+++ b/recipes/paraview/v1/gh200/repo/packages/paraview/gcc-compiler-pv501.patch
@@ -1,0 +1,22 @@
+--- ParaView-5.0.1.orig/VTK/CMake/vtkCompilerExtras.cmake	2016-03-28 17:07:10.000000000 +0200
++++ ParaView-5.0.1/VTK/CMake/vtkCompilerExtras.cmake	2016-12-13 17:21:25.382720945 +0100
+@@ -32,7 +32,7 @@
+     OUTPUT_VARIABLE _gcc_version_info
+     ERROR_VARIABLE _gcc_version_info)
+
+-  string (REGEX MATCH "[345]\\.[0-9]\\.[0-9]*"
++  string (REGEX MATCH "[3-9]\\.[0-9]\\.[0-9]*"
+     _gcc_version "${_gcc_version_info}")
+   if(NOT _gcc_version)
+     string (REGEX REPLACE ".*\\(GCC\\).*([34]\\.[0-9]).*" "\\1.0"
+--- ParaView-5.0.1.orig/VTK/CMake/GenerateExportHeader.cmake	2016-03-28 17:07:10.000000000 +0200
++++ ParaView-5.0.1/VTK/CMake/GenerateExportHeader.cmake	2016-12-13 17:21:25.382720945 +0100
+@@ -166,7 +166,7 @@
+     execute_process(COMMAND ${CMAKE_C_COMPILER} ARGS --version
+       OUTPUT_VARIABLE _gcc_version_info
+       ERROR_VARIABLE _gcc_version_info)
+-    string(REGEX MATCH "[345]\\.[0-9]\\.[0-9]*"
++    string(REGEX MATCH "[3-9]\\.[0-9]\\.[0-9]*"
+       _gcc_version "${_gcc_version_info}")
+     # gcc on mac just reports: "gcc (GCC) 3.3 20030304 ..." without the
+     # patch level, handle this here:

--- a/recipes/paraview/v1/gh200/repo/packages/paraview/h5part-parallel.patch
+++ b/recipes/paraview/v1/gh200/repo/packages/paraview/h5part-parallel.patch
@@ -1,0 +1,11 @@
+--- a/VTK/ThirdParty/h5part/vtkh5part/src/H5PartTypes.h	2020-10-12 17:56:08.942848601 -0400
++++ b/VTK/ThirdParty/h5part/vtkh5part/src/H5PartTypes.h	2020-10-12 17:56:50.656772295 -0400
+@@ -19,7 +19,7 @@
+ #endif
+  ;
+ 
+-#ifndef PARALLEL_IO
++#if !(defined(PARALLEL_IO) || defined(H5_HAVE_PARALLEL))
+ typedef unsigned long		MPI_Comm;
+ #endif
+ 

--- a/recipes/paraview/v1/gh200/repo/packages/paraview/kits_with_catalyst_5_12.patch
+++ b/recipes/paraview/v1/gh200/repo/packages/paraview/kits_with_catalyst_5_12.patch
@@ -1,0 +1,21 @@
+From 65ec5b0604576474141def0ba7f0c7b94f6b32ee Mon Sep 17 00:00:00 2001
+From: Ryan Krattiger <ryan.krattiger@kitware.com>
+Date: Fri, 8 Mar 2024 09:17:03 -0600
+
+---
+ VTK/IO/CatalystConduit/vtk.module | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/VTK/IO/CatalystConduit/vtk.module b/VTK/IO/CatalystConduit/vtk.module
+index c67f5a099d5..18e706e8c9f 100644
+--- a/VTK/IO/CatalystConduit/vtk.module
++++ b/VTK/IO/CatalystConduit/vtk.module
+@@ -5,7 +5,7 @@ LIBRARY_NAME
+ DESCRIPTION
+   Catalyst implementation for VTK, including Conduit to/from VTK conversion.
+ KIT
+-  VTK::IO
++  VTK::Parallel
+ SPDX_LICENSE_IDENTIFIER
+   BSD-3-Clause
+ SPDX_COPYRIGHT_TEXT

--- a/recipes/paraview/v1/gh200/repo/packages/paraview/package.py
+++ b/recipes/paraview/v1/gh200/repo/packages/paraview/package.py
@@ -81,6 +81,7 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
     variant("adios2", default=False, description="Enable ADIOS2 support", when="@5.8:")
     variant("visitbridge", default=False, description="Enable VisItBridge support")
     variant("raytracing", default=False, description="Enable Raytracing support")
+    variant("cdi", default=False, description="Enable CDI support")
     variant(
         "openpmd",
         default=False,
@@ -201,6 +202,8 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("ospray@2.1:2", when="+raytracing")
     depends_on("openimagedenoise", when="+raytracing")
     depends_on("ospray +mpi", when="+raytracing +mpi")
+
+    depends_on("cdi +netcdf", when="+cdi")
 
     depends_on("bzip2")
     depends_on("double-conversion")
@@ -686,5 +689,9 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
         # Currently only support OSPRay ray tracing
         cmake_args.append(self.define_from_variant("VTK_ENABLE_OSPRAY", "raytracing"))
         cmake_args.append(self.define_from_variant("VTKOSPRAY_ENABLE_DENOISER", "raytracing"))
+
+        # CDI
+        cmake_args.append(self.define_from_variant("PARAVIEW_PLUGIN_AUTOLOAD_CDIReader", "cdi"))
+        cmake_args.append(self.define_from_variant("PARAVIEW_PLUGIN_ENABLE_CDIReader", "cdi"))
 
         return cmake_args

--- a/recipes/paraview/v1/gh200/repo/packages/paraview/package.py
+++ b/recipes/paraview/v1/gh200/repo/packages/paraview/package.py
@@ -602,7 +602,7 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
                 "75": "turing",
                 "80": "ampere",
                 "86": "ampere",
-                "90": "native",
+                "90": "native", # FIXME workaround
             }
 
             cuda_arch_value = "native"

--- a/recipes/paraview/v1/gh200/repo/packages/paraview/package.py
+++ b/recipes/paraview/v1/gh200/repo/packages/paraview/package.py
@@ -1,0 +1,690 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import itertools
+import os
+import sys
+
+from spack.package import *
+
+
+class Paraview(CMakePackage, CudaPackage, ROCmPackage):
+    """ParaView is an open-source, multi-platform data analysis and
+    visualization application. This package includes the Catalyst
+    in-situ library for versions 5.7 and greater, otherwise use the
+    catalyst package.
+
+    """
+
+    homepage = "https://www.paraview.org"
+    url = "https://www.paraview.org/files/v5.7/ParaView-v5.7.0.tar.xz"
+    list_url = "https://www.paraview.org/files"
+    list_depth = 1
+    git = "https://gitlab.kitware.com/paraview/paraview.git"
+
+    maintainers("danlipsa", "vicentebolea", "kwryankrattiger")
+    tags = ["e4s"]
+
+    license("Apache-2.0")
+
+    version("master", branch="master", submodules=True)
+    version(
+        "5.12.0",
+        sha256="d289afe7b48533e2ca4a39a3b48d3874bfe67cf7f37fdd2131271c57e64de20d",
+        preferred=True,
+    )
+    version("5.11.2", sha256="5c5d2f922f30d91feefc43b4a729015dbb1459f54c938896c123d2ac289c7a1e")
+    version("5.11.1", sha256="5cc2209f7fa37cd3155d199ff6c3590620c12ca4da732ef7698dec37fa8dbb34")
+    version("5.11.0", sha256="9a0b8fe8b1a2cdfd0ace9a87fa87e0ec21ee0f6f0bcb1fdde050f4f585a25165")
+    version("5.10.1", sha256="520e3cdfba4f8592be477314c2f6c37ec73fb1d5b25ac30bdbd1c5214758b9c2")
+    version("5.10.0", sha256="86d85fcbec395cdbc8e1301208d7c76d8f48b15dc6b967ffbbaeee31242343a5")
+    version("5.9.1", sha256="0d486cb6fbf55e428845c9650486f87466efcb3155e40489182a7ea85dfd4c8d")
+    version("5.9.0", sha256="b03258b7cddb77f0ee142e3e77b377e5b1f503bcabc02bfa578298c99a06980d")
+    version("5.8.1", sha256="7653950392a0d7c0287c26f1d3a25cdbaa11baa7524b0af0e6a1a0d7d487d034")
+    version("5.8.0", sha256="219e4107abf40317ce054408e9c3b22fb935d464238c1c00c0161f1c8697a3f9")
+    version("5.7.0", sha256="e41e597e1be462974a03031380d9e5ba9a7efcdb22e4ca2f3fec50361f310874")
+    version("5.6.2", sha256="1f3710b77c58a46891808dbe23dc59a1259d9c6b7bb123aaaeaa6ddf2be882ea")
+    version("5.6.0", sha256="cb8c4d752ad9805c74b4a08f8ae6e83402c3f11e38b274dba171b99bb6ac2460")
+    version("5.5.2", sha256="64561f34c4402b88f3cb20a956842394dde5838efd7ebb301157a837114a0e2d")
+    version("5.5.1", sha256="a6e67a95a7a5711a2b5f95f38ccbff4912262b3e1b1af7d6b9afe8185aa85c0d")
+    version("5.5.0", sha256="1b619e326ff574de808732ca9a7447e4cd14e94ae6568f55b6581896cd569dff")
+    version("5.4.1", sha256="390d0f5dc66bf432e202a39b1f34193af4bf8aad2355338fa5e2778ea07a80e4")
+    version("5.4.0", sha256="f488d84a53b1286d2ee1967e386626c8ad05a6fe4e6cbdaa8d5e042f519f94a9")
+    version("5.3.0", sha256="046631bbf00775edc927314a3db207509666c9c6aadc7079e5159440fd2f88a0")
+    version("5.2.0", sha256="894e42ef8475bb49e4e7e64f4ee2c37c714facd18bfbb1d6de7f69676b062c96")
+    version("5.1.2", sha256="ff02b7307a256b7c6e8ad900dee5796297494df7f9a0804fe801eb2f66e6a187")
+    version("5.0.1", sha256="caddec83ec284162a2cbc46877b0e5a9d2cca59fb4ab0ea35b0948d2492950bb")
+    version("4.4.0", sha256="c2dc334a89df24ce5233b81b74740fc9f10bc181cd604109fd13f6ad2381fc73")
+
+    variant(
+        "development_files",
+        default=True,
+        description="Install include files for Catalyst or plugins support",
+    )
+    variant("python", default=False, description="Enable Python support", when="@5.6:")
+    variant("fortran", default=False, description="Enable Fortran support")
+    variant("mpi", default=True, description="Enable MPI support")
+    variant("osmesa", default=False, description="Enable OSMesa support")
+    variant("egl", default=False, description="Enable EGL in the OpenGL library being used")
+    variant("qt", default=False, description="Enable Qt (gui) support")
+    variant("opengl2", default=True, description="Enable OpenGL2 backend")
+    variant("examples", default=False, description="Build examples")
+    variant("hdf5", default=False, description="Use external HDF5")
+    variant("shared", default=True, description="Builds a shared version of the library")
+    variant("kits", default=True, description="Use module kits")
+    variant("pagosa", default=False, description="Build the pagosa adaptor")
+    variant("eyedomelighting", default=False, description="Enable Eye Dome Lighting feature")
+    variant("nvindex", default=False, description="Enable the pvNVIDIAIndeX plugin")
+    variant("tbb", default=False, description="Enable multi-threaded parallelism with TBB")
+    variant("adios2", default=False, description="Enable ADIOS2 support", when="@5.8:")
+    variant("visitbridge", default=False, description="Enable VisItBridge support")
+    variant("raytracing", default=False, description="Enable Raytracing support")
+    variant(
+        "openpmd",
+        default=False,
+        description="Enable openPMD support (w/ ADIOS2/HDF5)",
+        when="@5.9: +python",
+    )
+    variant("catalyst", default=False, description="Enable Catalyst 1", when="@5.7:")
+    variant(
+        "libcatalyst",
+        default=False,
+        description="Enable Catalyst 2 (libcatalyst) implementation",
+        when="@5.10:",
+    )
+
+    variant(
+        "advanced_debug",
+        default=False,
+        description="Enable all other debug flags beside build_type, such as VTK_DEBUG_LEAK",
+    )
+    variant(
+        "build_edition",
+        default="canonical",
+        multi=False,
+        values=("canonical", "catalyst_rendering", "catalyst", "rendering", "core"),
+        description="Build editions include only certain modules. "
+        "Editions are listed in decreasing order of size.",
+    )
+    variant(
+        "use_vtkm",
+        default="default",
+        multi=False,
+        values=("default", "on", "off"),
+        description="Build VTK-m with ParaView by setting PARAVIEW_USE_VTKM=ON,OFF."
+        ' "default" lets the build_edition make the decision.'
+        ' "on" or "off" will always override the build_edition.',
+    )
+
+    conflicts("~hdf5", when="+visitbridge")
+    conflicts("+adios2", when="@:5.10 ~mpi")
+    conflicts("+openpmd", when="~adios2 ~hdf5", msg="openPMD needs ADIOS2 and/or HDF5")
+    conflicts("~shared", when="+cuda")
+    conflicts("+cuda", when="@5.8:5.10")
+    conflicts("+cuda", when="use_vtkm=off")
+    conflicts("+rocm", when="+cuda")
+    conflicts("+rocm", when="use_vtkm=off")
+    conflicts("paraview@:5.10", when="+rocm")
+    # Legacy rendering dropped in 5.5
+    # See commit: https://gitlab.kitware.com/paraview/paraview/-/commit/798d328c
+    conflicts("~opengl2", when="@5.5:")
+    # in 5.7 you cannot reduce the size of the code for Catalyst builds.
+    conflicts("build_edition=catalyst_rendering", when="@:5.7")
+    conflicts("build_edition=catalyst", when="@:5.7")
+    conflicts("build_edition=rendering", when="@:5.7")
+    conflicts("build_edition=core", when="@:5.7")
+    # before 5.3.0, ParaView didn't have VTK-m
+    conflicts("use_vtkm=on", when="@:5.3")
+    # paraview@5.9.0 is recommended when using the xl compiler
+    # See https://gitlab.kitware.com/paraview/paraview/-/merge_requests/4433
+    conflicts(
+        "paraview@:5.8",
+        when="%xl_r",
+        msg="Use paraview@5.9.0 with %xl_r. Earlier versions are not able to build with xl.",
+    )
+
+    # We only support one single Architecture
+    for _arch, _other_arch in itertools.permutations(CudaPackage.cuda_arch_values, 2):
+        conflicts(
+            "cuda_arch={0}".format(_arch),
+            when="cuda_arch={0}".format(_other_arch),
+            msg="Paraview only accepts one architecture value",
+        )
+
+    for _arch in range(10, 14):
+        conflicts("cuda_arch=%d" % _arch, when="+cuda", msg="ParaView requires cuda_arch >= 20")
+
+    depends_on("cmake@3.3:", type="build")
+    depends_on("cmake@3.21:", type="build", when="+rocm")
+
+    extends("python", when="+python")
+
+    # VTK < 8.2.1 can't handle Python 3.8
+    # This affects Paraview <= 5.7 (VTK 8.2.0)
+    # https://gitlab.kitware.com/vtk/vtk/-/issues/17670
+    depends_on("python@3:3.7", when="@:5.7 +python", type=("build", "run"))
+    depends_on("python@3:", when="@5.8:+python", type=("build", "run"))
+
+    depends_on("py-numpy", when="+python", type=("build", "run"))
+    depends_on("py-mpi4py", when="+python+mpi", type=("build", "run"))
+
+    depends_on("py-matplotlib", when="+python", type="run")
+    depends_on("py-pandas@0.21:", when="+python", type="run")
+
+    # openPMD is implemented as a Python module and provides ADIOS2 and HDF5 backends
+    depends_on("openpmd-api@0.14.5: +python", when="+python +openpmd", type=("build", "run"))
+    depends_on("openpmd-api +adios2", when="+openpmd +adios2", type=("build", "run"))
+    depends_on("openpmd-api +hdf5", when="+openpmd +hdf5", type=("build", "run"))
+
+    depends_on("tbb", when="+tbb")
+
+    depends_on("mpi", when="+mpi")
+    depends_on("qt+opengl", when="@5.3.0:+qt+opengl2")
+    depends_on("qt~opengl", when="@5.3.0:+qt~opengl2")
+    depends_on("qt@:4", when="@:5.2.0+qt")
+
+    depends_on("gl@3.2:", when="+opengl2")
+    depends_on("gl@1.2:", when="~opengl2")
+    depends_on("glew", when="~egl")
+    depends_on("glew gl=egl", when="+egl")
+
+    depends_on("osmesa", when="+osmesa")
+    for p in ["linux", "cray"]:
+        depends_on("glx", when="~egl ~osmesa platform={}".format(p))
+        depends_on("libxt", when="~egl ~osmesa platform={}".format(p))
+    conflicts("+qt", when="+osmesa")
+    conflicts("+qt", when="+egl")
+    conflicts("+egl", when="+osmesa")
+
+    depends_on("ospray@2.1:2", when="+raytracing")
+    depends_on("openimagedenoise", when="+raytracing")
+    depends_on("ospray +mpi", when="+raytracing +mpi")
+
+    depends_on("bzip2")
+    depends_on("double-conversion")
+    depends_on("expat")
+    depends_on("eigen@3:")
+    depends_on("freetype")
+    depends_on("freetype@:2.10.2", when="@:5.8")
+    # depends_on('hdf5+mpi', when='+mpi')
+    # depends_on('hdf5~mpi', when='~mpi')
+    depends_on("hdf5+hl+mpi", when="+hdf5+mpi")
+    depends_on("hdf5+hl~mpi", when="+hdf5~mpi")
+    depends_on("hdf5@1.10:", when="+hdf5 @5.10:")
+    depends_on("adios2+mpi", when="+adios2+mpi")
+    depends_on("adios2~mpi", when="+adios2~mpi")
+    depends_on("silo", when="+visitbridge")
+    depends_on("silo+mpi", when="+visitbridge+mpi")
+    depends_on("silo~mpi", when="+visitbridge~mpi")
+    depends_on("boost", when="+visitbridge")
+    depends_on("jpeg")
+    depends_on("jsoncpp")
+    depends_on("libogg")
+    depends_on("libpng")
+    depends_on("libtheora")
+    depends_on("libtiff")
+    depends_on("netcdf-c")
+    depends_on("pegtl")
+    depends_on("protobuf@3.4:")
+    # Paraview 5.10 can't build with protobuf > 3.18
+    # https://github.com/spack/spack/issues/37437
+    depends_on("protobuf@3.4:3.18", when="@:5.10%oneapi")
+    depends_on("protobuf@3.4:3.18", when="@:5.10%intel@2021:")
+    depends_on("protobuf@3.4:3.18", when="@:5.10%xl")
+    depends_on("protobuf@3.4:3.18", when="@:5.10%xl_r")
+    # protobuf requires newer abseil-cpp, which in turn requires C++14,
+    # but paraview uses C++11 by default. Use for 5.8+ until ParaView updates
+    # its C++ standard level.
+    depends_on("protobuf@3.4:3.21", when="@5.8:%gcc")
+    depends_on("protobuf@3.4:3.21", when="@5.8:%clang")
+    depends_on("protobuf@3.4:3.21", when="@5.11:")
+    depends_on("protobuf@3.4:3.21", when="@master")
+    depends_on("libxml2")
+    depends_on("lz4")
+    depends_on("xz")
+    depends_on("zlib-api")
+    depends_on("libcatalyst@2:", when="+libcatalyst")
+    depends_on("hip@5.2:", when="+rocm")
+    for target in ROCmPackage.amdgpu_targets:
+        depends_on(
+            "kokkos@:3.7.01 +rocm amdgpu_target={0}".format(target),
+            when="+rocm amdgpu_target={0}".format(target),
+        )
+
+    # Older builds of pugi export their symbols differently,
+    # and pre-5.9 is unable to handle that.
+    depends_on("pugixml@:1.10", when="@:5.8")
+    depends_on("pugixml", when="@5.9:")
+
+    # ParaView depends on cli11 due to changes in MR
+    # https://gitlab.kitware.com/paraview/paraview/-/merge_requests/4951
+    depends_on("cli11@1.9.1", when="@5.10:")
+
+    # ParaView depends on nlohmann-json due to changes in MR
+    # https://gitlab.kitware.com/vtk/vtk/-/merge_requests/8550
+    depends_on("nlohmann-json", when="@5.11:")
+
+    # ParaView depends on proj@8.1.0 due to changes in MR
+    # v8.1.0 is required for VTK::GeoVis
+    # https://gitlab.kitware.com/vtk/vtk/-/merge_requests/8474
+    depends_on("proj@8.1.0", when="@5.11:")
+
+    patch("stl-reader-pv440.patch", when="@4.4.0")
+
+    # Broken gcc-detection - improved in 5.1.0, redundant later
+    patch("gcc-compiler-pv501.patch", when="@:5.0.1")
+
+    # Broken installation (ui_pqExportStateWizard.h) - fixed in 5.2.0
+    patch("ui_pqExportStateWizard.patch", when="@:5.1.2")
+
+    # Broken vtk-m config. Upstream catalyst changes
+    patch("vtkm-catalyst-pv551.patch", when="@5.5.0:5.5.2")
+
+    # Broken H5Part with external parallel HDF5
+    patch("h5part-parallel.patch", when="@5.7.0:5.7")
+
+    # Broken downstream FindMPI
+    patch("vtkm-findmpi-downstream.patch", when="@5.9.0")
+
+    # Include limits header wherever needed to fix compilation with GCC 11
+    patch("paraview-gcc11-limits.patch", when="@5.8:5.9 %gcc@11.1.0:")
+
+    # Fix IOADIOS2 module to work with kits
+    # https://gitlab.kitware.com/vtk/vtk/-/merge_requests/8653
+    patch("vtk-adios2-module-no-kit.patch", when="@5.8:5.11")
+
+    # Patch for paraview 5.9.0%xl_r
+    # https://gitlab.kitware.com/vtk/vtk/-/merge_requests/7591
+    patch("xlc-compilation-pv590.patch", when="@5.9.0%xl_r")
+
+    # intel oneapi doesn't compile some code in catalyst
+    patch("catalyst-etc_oneapi_fix.patch", when="@5.10.0:5.10.1%oneapi")
+
+    # Patch for paraview 5.8: ^hdf5@1.13.2:
+    # Even with ~hdf5, hdf5 is part of the dependency tree due to netcdf-c
+    # https://gitlab.kitware.com/vtk/vtk/-/merge_requests/9690
+    patch("vtk-xdmf2-hdf51.13.1.patch", when="@5.8:5.10")
+    patch("vtk-xdmf2-hdf51.13.2.patch", when="@5.8:5.11.0")
+
+    # Fix VTK to work with external freetype using CONFIG mode for find_package
+    patch("FindFreetype.cmake.patch", when="@5.10.1:")
+
+    # Fix VTK to remove deprecated ADIOS2 functions
+    # https://gitlab.kitware.com/vtk/vtk/-/merge_requests/10113
+    patch("adios2-remove-deprecated-functions.patch", when="@5.10:5.11 ^adios2@2.9:")
+
+    patch("exodusII-netcdf4.9.0.patch", when="@5.10.0:5.10.2")
+
+    patch("kits_with_catalyst_5_12.patch", when="@5.12.0")
+
+    generator("ninja", "make", default="ninja")
+    # https://gitlab.kitware.com/paraview/paraview/-/issues/21223
+    conflicts("generator=ninja", when="%xl")
+    conflicts("generator=ninja", when="%xl_r")
+
+    def url_for_version(self, version):
+        _urlfmt = "http://www.paraview.org/files/v{0}/ParaView-v{1}{2}.tar.{3}"
+        """Handle ParaView version-based custom URLs."""
+        if version < Version("5.1.0"):
+            return _urlfmt.format(version.up_to(2), version, "-source", "gz")
+        elif version < Version("5.6.1"):
+            return _urlfmt.format(version.up_to(2), version, "", "gz")
+        else:
+            return _urlfmt.format(version.up_to(2), version, "", "xz")
+
+    @property
+    def paraview_subdir(self):
+        """The paraview subdirectory name as paraview-major.minor"""
+        if self.spec.version == Version("master"):
+            return "paraview-5.11"
+        else:
+            return "paraview-{0}".format(self.spec.version.up_to(2))
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        if os.path.isdir(self.prefix.lib64):
+            lib_dir = self.prefix.lib64
+        else:
+            lib_dir = self.prefix.lib
+        env.set("ParaView_DIR", self.prefix)
+
+        if self.spec.version <= Version("5.7.0"):
+            env.set("PARAVIEW_VTK_DIR", join_path(lib_dir, "cmake", self.paraview_subdir))
+        else:
+            env.set("PARAVIEW_VTK_DIR", join_path(lib_dir, "cmake", self.paraview_subdir, "vtk"))
+
+    def flag_handler(self, name, flags):
+        if name == "ldflags" and self.spec.satisfies("%intel"):
+            flags.append("-shared-intel")
+            return (None, flags, None)
+        # -no-ipo prevents internal compiler error from multi-file
+        # optimization (https://github.com/spack/spack/issues/18192)
+        if (name == "cflags" or name == "cxxflags") and self.spec.satisfies("%intel"):
+            flags.append("-no-ipo")
+            return (None, None, flags)
+
+        if name in ("cflags", "cxxflags"):
+            # Constrain the HDF5 API
+            if self.spec.satisfies("@:5.9 +hdf5"):
+                if self.spec["hdf5"].satisfies("@1.10:"):
+                    flags.append("-DH5_USE_18_API")
+            elif self.spec.satisfies("@5.10: +hdf5"):
+                if self.spec["hdf5"].satisfies("@1.12:"):
+                    flags.append("-DH5_USE_110_API")
+
+        return (flags, None, None)
+
+    def setup_run_environment(self, env):
+        # paraview 5.5 and later
+        # - cmake under lib/cmake/paraview-5.5
+        # - libs  under lib
+        # - python bits under lib/python2.8/site-packages
+        if os.path.isdir(self.prefix.lib64):
+            lib_dir = self.prefix.lib64
+        else:
+            lib_dir = self.prefix.lib
+
+        env.set("ParaView_DIR", self.prefix)
+
+        if self.spec.version <= Version("5.7.0"):
+            env.set("PARAVIEW_VTK_DIR", join_path(lib_dir, "cmake", self.paraview_subdir))
+        else:
+            env.set("PARAVIEW_VTK_DIR", join_path(lib_dir, "cmake", self.paraview_subdir, "vtk"))
+
+        if self.spec.version <= Version("5.4.1"):
+            lib_dir = join_path(lib_dir, self.paraview_subdir)
+
+        env.prepend_path("LIBRARY_PATH", lib_dir)
+        env.prepend_path("LD_LIBRARY_PATH", lib_dir)
+
+        if "+python" in self.spec:
+            if self.spec.version <= Version("5.4.1"):
+                pv_pydir = join_path(lib_dir, "site-packages")
+                env.prepend_path("PYTHONPATH", pv_pydir)
+                env.prepend_path("PYTHONPATH", join_path(pv_pydir, "vtk"))
+            else:
+                python_version = self.spec["python"].version.up_to(2)
+                pv_pydir = join_path(lib_dir, "python{0}".format(python_version), "site-packages")
+                if "+shared" in self.spec or self.spec.version <= Version("5.7.0"):
+                    env.prepend_path("PYTHONPATH", pv_pydir)
+                    # The Trilinos Catalyst adapter requires
+                    # the vtkmodules directory in PYTHONPATH
+                    env.prepend_path("PYTHONPATH", join_path(pv_pydir, "vtkmodules"))
+                else:
+                    env.prepend_path("PYTHONPATH", join_path(pv_pydir, "_paraview.zip"))
+                    env.prepend_path("PYTHONPATH", join_path(pv_pydir, "_vtk.zip"))
+
+    def cmake_args(self):
+        """Populate cmake arguments for ParaView."""
+        spec = self.spec
+
+        def variant_bool(feature, on="ON", off="OFF"):
+            """Ternary for spec variant to ON/OFF string"""
+            if feature in spec:
+                return on
+            return off
+
+        def nvariant_bool(feature):
+            """Negated ternary for spec variant to OFF/ON string"""
+            return variant_bool(feature, on="OFF", off="ON")
+
+        def use_x11():
+            """Return false if osmesa or egl are requested"""
+            if "+osmesa" in spec or "+egl" in spec:
+                return "OFF"
+            if spec.satisfies("platform=windows"):
+                return "OFF"
+            return "ON"
+
+        rendering = variant_bool("+opengl2", "OpenGL2", "OpenGL")
+        includes = variant_bool("+development_files")
+
+        cmake_args = [
+            "-DVTK_OPENGL_HAS_OSMESA:BOOL=%s" % variant_bool("+osmesa"),
+            "-DVTK_USE_X:BOOL=%s" % use_x11(),
+            "-DPARAVIEW_INSTALL_DEVELOPMENT_FILES:BOOL=%s" % includes,
+            "-DBUILD_TESTING:BOOL=OFF",
+            "-DOpenGL_GL_PREFERENCE:STRING=LEGACY",
+            self.define_from_variant("PARAVIEW_ENABLE_VISITBRIDGE", "visitbridge"),
+            self.define_from_variant("VISIT_BUILD_READER_Silo", "visitbridge"),
+        ]
+
+        if "+egl" in spec:
+            cmake_args.append("-DVTK_OPENGL_HAS_EGL:BOOL=ON")
+
+        if spec.satisfies("@5.12:"):
+            cmake_args.append("-DVTK_MODULE_USE_EXTERNAL_VTK_fast_float:BOOL=OFF")
+            cmake_args.append("-DVTK_MODULE_USE_EXTERNAL_VTK_token:BOOL=OFF")
+
+        if spec.satisfies("@5.11:"):
+            cmake_args.append("-DVTK_MODULE_USE_EXTERNAL_VTK_verdict:BOOL=OFF")
+
+        if spec.satisfies("@5.10:"):
+            cmake_args.extend(
+                [
+                    "-DVTK_MODULE_USE_EXTERNAL_ParaView_vtkcatalyst:BOOL=OFF",
+                    "-DVTK_MODULE_USE_EXTERNAL_VTK_ioss:BOOL=OFF",
+                    "-DVTK_MODULE_USE_EXTERNAL_VTK_exprtk:BOOL=OFF",
+                    "-DVTK_MODULE_USE_EXTERNAL_VTK_fmt:BOOL=OFF",
+                ]
+            )
+
+        if spec.satisfies("@:5.7") and spec["cmake"].satisfies("@3.17:"):
+            cmake_args.append("-DFPHSA_NAME_MISMATCHED:BOOL=ON")
+
+        if spec.satisfies("@5.7:"):
+            if spec.satisfies("@5.8:"):
+                cmake_args.extend(
+                    [
+                        "-DPARAVIEW_BUILD_EDITION:STRING=%s"
+                        % spec.variants["build_edition"].value.upper(),
+                        "-DPARAVIEW_USE_QT:BOOL=%s" % variant_bool("+qt"),
+                        "-DPARAVIEW_BUILD_WITH_EXTERNAL=ON",
+                    ]
+                )
+                if spec.satisfies("%cce"):
+                    cmake_args.append("-DVTK_PYTHON_OPTIONAL_LINK:BOOL=OFF")
+            else:  # @5.7:
+                cmake_args.extend(
+                    [
+                        "-DPARAVIEW_ENABLE_CATALYST:BOOL=ON",
+                        "-DPARAVIEW_BUILD_QT_GUI:BOOL=%s" % variant_bool("+qt"),
+                        "-DPARAVIEW_USE_EXTERNAL:BOOL=ON",
+                    ]
+                )
+
+            cmake_args.extend(
+                [
+                    "-DPARAVIEW_ENABLE_EXAMPLES:BOOL=%s" % variant_bool("+examples"),
+                    "-DVTK_MODULE_USE_EXTERNAL_ParaView_cgns=OFF",
+                    "-DVTK_MODULE_USE_EXTERNAL_VTK_gl2ps=OFF",
+                    "-DVTK_MODULE_USE_EXTERNAL_VTK_libharu=OFF",
+                    "-DVTK_MODULE_USE_EXTERNAL_VTK_utf8=OFF",
+                ]
+            )
+        else:
+            cmake_args.extend(
+                [
+                    "-DPARAVIEW_BUILD_EXAMPLES:BOOL=%s" % variant_bool("+examples"),
+                    "-DVTK_RENDERING_BACKEND:STRING=%s" % rendering,
+                    "-DPARAVIEW_BUILD_QT_GUI:BOOL=%s" % variant_bool("+qt"),
+                    "-DVTK_USE_SYSTEM_LIBRARIES:BOOL=ON",
+                    "-DVTK_USE_SYSTEM_CGNS:BOOL=OFF",
+                    "-DVTK_USE_SYSTEM_DIY2:BOOL=OFF",
+                    "-DVTK_USE_SYSTEM_GL2PS:BOOL=OFF",
+                    "-DVTK_USE_SYSTEM_ICET:BOOL=OFF",
+                    "-DVTK_USE_SYSTEM_LIBHARU:BOOL=OFF",
+                    "-DVTK_USE_SYSTEM_NETCDFCPP:BOOL=OFF",
+                    "-DVTK_USE_SYSTEM_UTF8:BOOL=OFF",
+                    "-DVTK_USE_SYSTEM_XDMF2:BOOL=OFF",
+                    "-DVTK_USE_SYSTEM_XDMF3:BOOL=OFF",
+                ]
+            )
+
+        if "+adios2" in spec:
+            cmake_args.extend(["-DPARAVIEW_ENABLE_ADIOS2:BOOL=ON"])
+
+        # The assumed qt version changed to QT5 (as of paraview 5.2.1),
+        # so explicitly specify which QT major version is actually being used
+        if "+qt" in spec:
+            cmake_args.extend(["-DPARAVIEW_QT_VERSION=%s" % spec["qt"].version[0]])
+
+        if "+fortran" in spec:
+            cmake_args.append("-DPARAVIEW_USE_FORTRAN:BOOL=ON")
+
+        # CMake flags for python have changed with newer ParaView versions
+        # Make sure Spack uses the right cmake flags
+        if "+python" in spec:
+            py_use_opt = "USE" if spec.satisfies("@5.8:") else "ENABLE"
+            py_ver_opt = "PARAVIEW" if spec.satisfies("@5.7:") else "VTK"
+            py_ver_val = 3
+            cmake_args.extend(
+                [
+                    "-DPARAVIEW_%s_PYTHON:BOOL=ON" % py_use_opt,
+                    "-D%s_PYTHON_VERSION:STRING=%d" % (py_ver_opt, py_ver_val),
+                ]
+            )
+            if spec.satisfies("@:5.6"):
+                cmake_args.append("-DVTK_USE_SYSTEM_MPI4PY:BOOL=%s" % variant_bool("+mpi"))
+
+        else:
+            cmake_args.append("-DPARAVIEW_ENABLE_PYTHON:BOOL=OFF")
+
+        if "+mpi" in spec:
+            mpi_args = [
+                "-DPARAVIEW_USE_MPI:BOOL=ON",
+                "-DMPIEXEC:FILEPATH=%s/bin/mpiexec" % spec["mpi"].prefix,
+            ]
+            if not sys.platform == "win32":
+                mpi_args.extend(
+                    [
+                        "-DMPI_CXX_COMPILER:PATH=%s" % spec["mpi"].mpicxx,
+                        "-DMPI_C_COMPILER:PATH=%s" % spec["mpi"].mpicc,
+                        "-DMPI_Fortran_COMPILER:PATH=%s" % spec["mpi"].mpifc,
+                    ]
+                )
+            cmake_args.extend(mpi_args)
+
+        cmake_args.append("-DPARAVIEW_BUILD_SHARED_LIBS:BOOL=%s" % variant_bool("+shared"))
+
+        # VTK-m added to ParaView in 5.3.0 and up
+        if spec.satisfies("@5.3.0:") and spec.variants["use_vtkm"].value != "default":
+            cmake_args.append(
+                "-DPARAVIEW_USE_VTKM:BOOL=%s" % spec.variants["use_vtkm"].value.upper()
+            )
+
+        if spec.satisfies("@5.8:"):
+            cmake_args.append("-DPARAVIEW_USE_CUDA:BOOL=%s" % variant_bool("+cuda"))
+        elif spec.satisfies("@5.7:"):
+            cmake_args.append("-DVTK_USE_CUDA:BOOL=%s" % variant_bool("+cuda"))
+        else:
+            cmake_args.append("-DVTKm_ENABLE_CUDA:BOOL=%s" % variant_bool("+cuda"))
+
+        # VTK-m expects cuda_arch to be the arch name vs. the arch version.
+        if spec.satisfies("+cuda"):
+            supported_cuda_archs = {
+                # VTK-m and transitively ParaView does not support Tesla Arch
+                "20": "fermi",
+                "21": "fermi",
+                "30": "kepler",
+                "32": "kepler",
+                "35": "kepler",
+                "37": "kepler",
+                "50": "maxwel",
+                "52": "maxwel",
+                "53": "maxwel",
+                "60": "pascal",
+                "61": "pascal",
+                "62": "pascal",
+                "70": "volta",
+                "72": "volta",
+                "75": "turing",
+                "80": "ampere",
+                "86": "ampere",
+                "90": "native",
+            }
+
+            cuda_arch_value = "native"
+            requested_arch = spec.variants["cuda_arch"].value
+
+            # ParaView/VTK-m only accepts one arch, default to first element
+            if requested_arch[0] != "none":
+                try:
+                    cuda_arch_value = supported_cuda_archs[requested_arch[0]]
+                except KeyError:
+                    raise InstallError("Incompatible cuda_arch=" + requested_arch[0])
+
+            cmake_args.append(self.define("VTKm_CUDA_Architecture", cuda_arch_value))
+
+        if "darwin" in spec.architecture:
+            cmake_args.extend(
+                ["-DVTK_USE_X:BOOL=OFF", "-DPARAVIEW_DO_UNIX_STYLE_INSTALLS:BOOL=ON"]
+            )
+
+        if "+kits" in spec:
+            if spec.satisfies("@5.0:5.6"):
+                cmake_args.append("-DVTK_ENABLE_KITS:BOOL=ON")
+            elif spec.satisfies("@5.7"):
+                # cmake_args.append('-DPARAVIEW_ENABLE_KITS:BOOL=ON')
+                # Kits are broken with 5.7
+                cmake_args.append("-DPARAVIEW_ENABLE_KITS:BOOL=OFF")
+            else:
+                cmake_args.append("-DPARAVIEW_BUILD_WITH_KITS:BOOL=ON")
+
+        if "+pagosa" in spec:
+            cmake_args.append("-DPARAVIEW_BUILD_PAGOSA_ADAPTOR:BOOL=ON")
+
+        if "+eyedomelighting" in spec:
+            cmake_args.append("-DPARAVIEW_BUILD_PLUGIN_EyeDomeLighting:BOOL=ON")
+
+        if "+tbb" in spec:
+            cmake_args.append("-DVTK_SMP_IMPLEMENTATION_TYPE=TBB")
+
+        if "+nvindex" in spec:
+            cmake_args.append("-DPARAVIEW_PLUGIN_ENABLE_pvNVIDIAIndeX:BOOL=ON")
+
+        # Hide git from Paraview so it will not use `git describe`
+        # to find its own version number
+        if spec.satisfies("@5.4.0:5.4.1"):
+            cmake_args.extend(["-DGIT_EXECUTABLE=FALSE"])
+
+        # A bug that has been found in vtk causes an error for
+        # intel builds for version 5.6.  This should be revisited
+        # with later versions of Paraview to see if the issues still
+        # arises.
+        if "%intel" in spec and spec.version >= Version("5.6"):
+            cmake_args.append("-DPARAVIEW_ENABLE_MOTIONFX:BOOL=OFF")
+
+        # Encourage Paraview to use the correct Python libs
+        if spec.satisfies("+python"):
+            pylibdirs = spec["python"].libs.directories
+            cmake_args.append("-DCMAKE_INSTALL_RPATH={0}".format(":".join(self.rpath + pylibdirs)))
+
+        if "+advanced_debug" in spec:
+            cmake_args.append("-DVTK_DEBUG_LEAKS:BOOL=ON")
+
+        if spec.satisfies("@5.11:"):
+            cmake_args.append("-DPARAVIEW_USE_HIP:BOOL=%s" % variant_bool("+rocm"))
+            if "+rocm" in spec:
+                archs = spec.variants["amdgpu_target"].value
+                if archs != "none":
+                    arch_str = ",".join(archs)
+                    cmake_args.append("-DCMAKE_HIP_ARCHITECTURES=%s" % arch_str)
+                cmake_args.append("-DKokkos_CXX_COMPILER=%s" % spec["hip"].hipcc)
+
+        if "+catalyst" in spec:
+            cmake_args.append("-DVTK_MODULE_ENABLE_ParaView_Catalyst=YES")
+            if "+python" in spec:
+                cmake_args.append("-DVTK_MODULE_ENABLE_ParaView_PythonCatalyst=YES")
+
+        if "+libcatalyst" in spec:
+            cmake_args.append("-DVTK_MODULE_ENABLE_ParaView_InSitu=YES")
+            cmake_args.append("-DPARAVIEW_ENABLE_CATALYST=YES")
+
+        cmake_args.append(self.define_from_variant("PARAVIEW_ENABLE_RAYTRACING", "raytracing"))
+        # Currently only support OSPRay ray tracing
+        cmake_args.append(self.define_from_variant("VTK_ENABLE_OSPRAY", "raytracing"))
+        cmake_args.append(self.define_from_variant("VTKOSPRAY_ENABLE_DENOISER", "raytracing"))
+
+        return cmake_args

--- a/recipes/paraview/v1/gh200/repo/packages/paraview/paraview-gcc11-limits.patch
+++ b/recipes/paraview/v1/gh200/repo/packages/paraview/paraview-gcc11-limits.patch
@@ -1,0 +1,49 @@
+Index: ParaView-v5.9.1/VTK/Common/Core/vtkGenericDataArrayLookupHelper.h
+===================================================================
+--- ParaView-v5.9.1.orig/VTK/Common/Core/vtkGenericDataArrayLookupHelper.h
++++ ParaView-v5.9.1/VTK/Common/Core/vtkGenericDataArrayLookupHelper.h
+@@ -25,6 +25,7 @@
+ #include "vtkIdList.h"
+ #include <algorithm>
+ #include <cmath>
++#include <limits>
+ #include <unordered_map>
+ #include <vector>
+ 
+Index: ParaView-v5.9.1/VTK/Rendering/Core/vtkColorTransferFunction.cxx
+===================================================================
+--- ParaView-v5.9.1.orig/VTK/Rendering/Core/vtkColorTransferFunction.cxx
++++ ParaView-v5.9.1/VTK/Rendering/Core/vtkColorTransferFunction.cxx
+@@ -21,6 +21,7 @@
+ #include <algorithm>
+ #include <cmath>
+ #include <iterator>
++#include <limits>
+ #include <set>
+ #include <vector>
+ 
+Index: ParaView-v5.9.1/VTK/Common/DataModel/vtkPiecewiseFunction.cxx
+===================================================================
+--- ParaView-v5.9.1.orig/VTK/Common/DataModel/vtkPiecewiseFunction.cxx
++++ ParaView-v5.9.1/VTK/Common/DataModel/vtkPiecewiseFunction.cxx
+@@ -22,6 +22,7 @@
+ #include <cassert>
+ #include <cmath>
+ #include <iterator>
++#include <limits>
+ #include <set>
+ #include <vector>
+ 
+Index: ParaView-v5.9.1/VTK/Filters/HyperTree/vtkHyperTreeGridThreshold.cxx
+===================================================================
+--- ParaView-v5.9.1.orig/VTK/Filters/HyperTree/vtkHyperTreeGridThreshold.cxx
++++ ParaView-v5.9.1/VTK/Filters/HyperTree/vtkHyperTreeGridThreshold.cxx
+@@ -27,6 +27,7 @@
+ #include "vtkHyperTreeGridNonOrientedCursor.h"
+ 
+ #include <cmath>
++#include <limits>
+ 
+ vtkStandardNewMacro(vtkHyperTreeGridThreshold);
+ 
+

--- a/recipes/paraview/v1/gh200/repo/packages/paraview/stl-reader-pv440.patch
+++ b/recipes/paraview/v1/gh200/repo/packages/paraview/stl-reader-pv440.patch
@@ -1,0 +1,11 @@
+--- ParaView-4.4.0.orig/VTK/IO/Geometry/vtkSTLReader.cxx	2015-09-11 19:59:24.000000000 +0200
++++ ParaView-4.4.0/VTK/IO/Geometry/vtkSTLReader.cxx	2016-06-19 12:59:50.769770143 +0200
+@@ -448,7 +448,7 @@
+           done = done || (fscanf(fp,"%s", line)==EOF);
+           }
+         }
+-      if (!done)
++      else if (!done)
+         {
+         done = (fgets(line, 255, fp) == 0);
+         lineCount++;

--- a/recipes/paraview/v1/gh200/repo/packages/paraview/ui_pqExportStateWizard.patch
+++ b/recipes/paraview/v1/gh200/repo/packages/paraview/ui_pqExportStateWizard.patch
@@ -1,0 +1,11 @@
+--- ParaView-5.0.1.orig/Qt/Components/CMakeLists.txt	2016-03-28 17:07:03.000000000 +0200
++++ ParaView-5.0.1/Qt/Components/CMakeLists.txt	2016-12-13 17:38:42.713553032 +0100
+@@ -656,7 +656,7 @@
+ #the pqSGExportStateWizard has subclasses that directly access
+ #the UI file, and currently we don't have a clean way to break this hard
+ #dependency, so for no we install this ui file.
+-if(PARAVIEW_INSTALL_DEVELOPMENT_FILES)
++if(PARAVIEW_INSTALL_DEVELOPMENT_FILES AND PARAVIEW_ENABLE_PYTHON)
+   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/ui_pqExportStateWizard.h"
+           DESTINATION "${VTK_INSTALL_INCLUDE_DIR}")
+ endif()

--- a/recipes/paraview/v1/gh200/repo/packages/paraview/vtk-adios2-module-no-kit.patch
+++ b/recipes/paraview/v1/gh200/repo/packages/paraview/vtk-adios2-module-no-kit.patch
@@ -1,0 +1,24 @@
+From 19cd0302104e94421813427071351aa5326e4dbb Mon Sep 17 00:00:00 2001
+From: Ryan Krattiger <ryan.krattiger@kitware.com>
+Date: Thu, 2 Dec 2021 16:58:10 -0600
+Subject: [PATCH] ADIOS2: Move IOADIOS2 to StandAlone kit
+
+---
+ IO/ADIOS2/vtk.module                   |  2 -
+ 1 files changed, 0 insertions(+), 2 deletions(-)
+
+diff --git a/VTK/IO/ADIOS2/vtk.module b/VTK/IO/ADIOS2/vtk.module
+index 5ee89b9a65e..b89e54d7683 100644
+--- a/VTK/IO/ADIOS2/vtk.module
++++ b/VTK/IO/ADIOS2/vtk.module
+@@ -3,7 +3,5 @@ NAME
+ LIBRARY_NAME
+   vtkIOADIOS2
+-KIT
+-  VTK::IO
+ DEPENDS
+   VTK::CommonCore
+   VTK::CommonExecutionModel
+-- 
+GitLab
+

--- a/recipes/paraview/v1/gh200/repo/packages/paraview/vtk-xdmf2-hdf51.13.1.patch
+++ b/recipes/paraview/v1/gh200/repo/packages/paraview/vtk-xdmf2-hdf51.13.1.patch
@@ -1,0 +1,61 @@
+From 3a536a3c6b949cb1c9dd147c3a395c3ff31856e8 Mon Sep 17 00:00:00 2001
+From: Ben Boeckel <ben.boeckel@kitware.com>
+Date: Thu, 14 Apr 2022 12:53:36 -0400
+Subject: [PATCH 1/6] xdmf2: install `XdmfExport.h`
+
+---
+ VTK/ThirdParty/xdmf2/vtkxdmf2/libsrc/CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/VTK/ThirdParty/xdmf2/vtkxdmf2/libsrc/CMakeLists.txt b/VTK/ThirdParty/xdmf2/vtkxdmf2/libsrc/CMakeLists.txt
+index 274dbc4423c..a47bf4ee4d9 100644
+--- a/VTK/ThirdParty/xdmf2/vtkxdmf2/libsrc/CMakeLists.txt
++++ b/VTK/ThirdParty/xdmf2/vtkxdmf2/libsrc/CMakeLists.txt
+@@ -276,6 +276,7 @@ vtk_module_add_module(VTK::xdmf2
+           ${XdmfModelSource}
+   SOURCES ${XdmfExtraSource}
+   HEADERS Xdmf.h
++          XdmfExport.h
+           "${CMAKE_CURRENT_BINARY_DIR}/XdmfConfig.h"
+   HEADERS_SUBDIR "vtkxdmf2/libsrc")
+ set_target_properties(xdmf2
+-- 
+GitLab
+
+
+From 1456c9e6ab2b244d225dcfc0a7f985933c09d5f3 Mon Sep 17 00:00:00 2001
+From: Ben Boeckel <ben.boeckel@kitware.com>
+Date: Thu, 14 Apr 2022 15:20:13 -0400
+Subject: [PATCH 6/6] xdmf2: support HDF5 1.13.1
+
+---
+ VTK/ThirdParty/xdmf2/vtkxdmf2/libsrc/XdmfH5Driver.cxx | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/VTK/ThirdParty/xdmf2/vtkxdmf2/libsrc/XdmfH5Driver.cxx b/VTK/ThirdParty/xdmf2/vtkxdmf2/libsrc/XdmfH5Driver.cxx
+index 6a4966bb231..1a412b56d02 100644
+--- a/VTK/ThirdParty/xdmf2/vtkxdmf2/libsrc/XdmfH5Driver.cxx
++++ b/VTK/ThirdParty/xdmf2/vtkxdmf2/libsrc/XdmfH5Driver.cxx
+@@ -156,6 +156,9 @@ static herr_t H5FD_dsm_write(H5FD_t *_file, H5FD_mem_t type, hid_t fapl_id, hadd
+ }
+ 
+ static const H5FD_class_t H5FD_dsm_g = {
++#if (H5_VERS_MAJOR>1)||((H5_VERS_MAJOR==1)&&(H5_VERS_MINOR>=13))
++    H5_VFD_RESERVED + 0xd3f2,   /*value         */
++#endif
+     "dsm",                      /*name          */
+     MAXADDR,                    /*maxaddr       */
+     H5F_CLOSE_WEAK,             /*fc_degree     */
+@@ -193,6 +196,10 @@ static const H5FD_class_t H5FD_dsm_g = {
+ #endif
+     NULL,                       /*lock          */
+     NULL,                       /*unlock        */
++#if (H5_VERS_MAJOR>1)||((H5_VERS_MAJOR==1)&&(H5_VERS_MINOR>=13))
++    NULL,                       /*del           */
++    NULL,                       /*ctl           */
++#endif
+     H5FD_FLMAP_SINGLE           /*fl_map        */
+ };
+ 
+-- 
+GitLab

--- a/recipes/paraview/v1/gh200/repo/packages/paraview/vtk-xdmf2-hdf51.13.2.patch
+++ b/recipes/paraview/v1/gh200/repo/packages/paraview/vtk-xdmf2-hdf51.13.2.patch
@@ -1,0 +1,36 @@
+From 2cc0d020359f714587d14b2f25a2c5f235f829c9 Mon Sep 17 00:00:00 2001
+From: Ryan Krattiger <ryan.krattiger@kitware.com>
+Date: Tue, 15 Nov 2022 15:00:36 -0600
+Subject: [PATCH] Xdmf2: Update HDF5 driver for 1.13.2
+
+---
+ VTK/ThirdParty/xdmf2/vtkxdmf2/libsrc/XdmfH5Driver.cxx | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/VTK/ThirdParty/xdmf2/vtkxdmf2/libsrc/XdmfH5Driver.cxx b/VTK/ThirdParty/xdmf2/vtkxdmf2/libsrc/XdmfH5Driver.cxx
+index 1a412b56d02..ff4427d0265 100644
+--- a/VTK/ThirdParty/xdmf2/vtkxdmf2/libsrc/XdmfH5Driver.cxx
++++ b/VTK/ThirdParty/xdmf2/vtkxdmf2/libsrc/XdmfH5Driver.cxx
+@@ -157,6 +157,7 @@ static herr_t H5FD_dsm_write(H5FD_t *_file, H5FD_mem_t type, hid_t fapl_id, hadd
+ 
+ static const H5FD_class_t H5FD_dsm_g = {
+ #if (H5_VERS_MAJOR>1)||((H5_VERS_MAJOR==1)&&(H5_VERS_MINOR>=13))
++    0,                          /*version       */
+     H5_VFD_RESERVED + 0xd3f2,   /*value         */
+ #endif
+     "dsm",                      /*name          */
+@@ -190,6 +191,12 @@ static const H5FD_class_t H5FD_dsm_g = {
+     NULL,                       /*get_handle    */
+     H5FD_dsm_read,              /*read          */
+     H5FD_dsm_write,             /*write         */
++#if (H5_VERS_MAJOR>1)||((H5_VERS_MAJOR==1)&&(H5_VERS_MINOR>=13))
++    NULL,                       /*read_vector     */
++    NULL,                       /*write_vector    */
++    NULL,                       /*read_selection  */
++    NULL,                       /*write_selection */
++#endif
+     NULL,                       /*flush         */
+ #if (H5_VERS_MAJOR>1)||((H5_VERS_MAJOR==1)&&(H5_VERS_MINOR>=8))
+     NULL,                       /* truncate     */
+-- 
+GitLab

--- a/recipes/paraview/v1/gh200/repo/packages/paraview/vtkm-catalyst-pv551.patch
+++ b/recipes/paraview/v1/gh200/repo/packages/paraview/vtkm-catalyst-pv551.patch
@@ -1,0 +1,510 @@
+# The VTK-m changes are slated for paraview-5.5.x
+#
+# The catalyst changes (the working directory for output) are slated for
+# paraview-5.6.
+# They are API-compatible with paraview-5.5 but not ABI compatible.
+#
+# https://gitlab.kitware.com/vtk/vtk-m/merge_requests/1166
+# https://gitlab.kitware.com/paraview/paraview/merge_requests/2433
+# https://gitlab.kitware.com/paraview/paraview/merge_requests/2436
+#
+--- ParaView-v5.5.0/VTK/ThirdParty/vtkm/vtk-m/CMake/VTKmDetermineVersion.cmake.orig	2018-04-06 22:03:33.000000000 +0200
++++ ParaView-v5.5.0/VTK/ThirdParty/vtkm/vtk-m/CMake/VTKmDetermineVersion.cmake	2018-04-23 12:00:23.708544206 +0200
+@@ -51,6 +51,8 @@
+         ERROR_QUIET
+         OUTPUT_STRIP_TRAILING_WHITESPACE
+         ERROR_STRIP_TRAILING_WHITESPACE)
++    else()
++      set(output)
+     endif()
+   else()
+     set(result 0)
+@@ -75,7 +77,7 @@
+ 
+ # Extracts components from a version string. See determine_version() for usage.
+ function(extract_version_components version_string var_prefix)
+-  string(REGEX MATCH "([0-9]+)\\.([0-9]+)\\.([0-9]+)[-]*(.*)"
++  string(REGEX MATCH "^([0-9]+)\\.([0-9]+)\\.([0-9]+)[-]*(.*)$"
+     version_matches "${version_string}")
+   if(CMAKE_MATCH_0)
+     set(full ${CMAKE_MATCH_0})
+--- ParaView-v5.5.0/CoProcessing/Catalyst/vtkCPProcessor.cxx.orig	2018-04-06 22:03:33.000000000 +0200
++++ ParaView-v5.5.0/CoProcessing/Catalyst/vtkCPProcessor.cxx	2018-05-11 12:02:26.894772713 +0200
+@@ -38,6 +38,7 @@
+ #include "vtkStringArray.h"
+ 
+ #include <list>
++#include <vtksys/SystemTools.hxx>
+ 
+ struct vtkCPProcessorInternals
+ {
+@@ -47,12 +48,13 @@
+ };
+ 
+ vtkStandardNewMacro(vtkCPProcessor);
+-vtkMultiProcessController* vtkCPProcessor::Controller = NULL;
++vtkMultiProcessController* vtkCPProcessor::Controller = nullptr;
+ //----------------------------------------------------------------------------
+ vtkCPProcessor::vtkCPProcessor()
+ {
+   this->Internal = new vtkCPProcessorInternals;
+-  this->InitializationHelper = NULL;
++  this->InitializationHelper = nullptr;
++  this->WorkingDirectory = nullptr;
+ }
+ 
+ //----------------------------------------------------------------------------
+@@ -61,14 +63,15 @@
+   if (this->Internal)
+   {
+     delete this->Internal;
+-    this->Internal = NULL;
++    this->Internal = nullptr;
+   }
+ 
+   if (this->InitializationHelper)
+   {
+     this->InitializationHelper->Delete();
+-    this->InitializationHelper = NULL;
++    this->InitializationHelper = nullptr;
+   }
++  this->SetWorkingDirectory(nullptr);
+ }
+ 
+ //----------------------------------------------------------------------------
+@@ -95,7 +98,7 @@
+ {
+   if (which < 0 || which >= this->GetNumberOfPipelines())
+   {
+-    return NULL;
++    return nullptr;
+   }
+   int counter = 0;
+   vtkCPProcessorInternals::PipelineListIterator iter = this->Internal->Pipelines.begin();
+@@ -108,7 +111,7 @@
+     counter++;
+     iter++;
+   }
+-  return NULL;
++  return nullptr;
+ }
+ 
+ //----------------------------------------------------------------------------
+@@ -130,17 +133,41 @@
+ }
+ 
+ //----------------------------------------------------------------------------
+-int vtkCPProcessor::Initialize()
++int vtkCPProcessor::Initialize(const char* workingDirectory)
+ {
+-  if (this->InitializationHelper == NULL)
++  if (this->InitializationHelper == nullptr)
+   {
+     this->InitializationHelper = this->NewInitializationHelper();
+   }
++  // make sure the directory exists here so that we only do it once
++  if (workingDirectory)
++  {
++    vtkMultiProcessController* controller = vtkMultiProcessController::GetGlobalController();
++    int success = 1;
++    if (controller == nullptr || controller->GetLocalProcessId() == 0)
++    {
++      success = vtksys::SystemTools::MakeDirectory(workingDirectory) == true ? 1 : 0;
++      if (success == 0)
++      {
++        vtkWarningMacro("Could not make "
++          << workingDirectory << " directory. "
++          << "Results will be generated in current working directory instead.");
++      }
++    }
++    if (controller)
++    {
++      controller->Broadcast(&success, 1, 0);
++    }
++    if (success)
++    {
++      this->SetWorkingDirectory(workingDirectory);
++    }
++  }
+   return 1;
+ }
+ 
+ //----------------------------------------------------------------------------
+-int vtkCPProcessor::Initialize(vtkMPICommunicatorOpaqueComm& comm)
++int vtkCPProcessor::Initialize(vtkMPICommunicatorOpaqueComm& comm, const char* workingDirectory)
+ {
+ #ifdef PARAVIEW_USE_MPI
+   if (vtkCPProcessor::Controller)
+@@ -148,7 +175,7 @@
+     vtkErrorMacro("Can only initialize with a communicator once per process.");
+     return 0;
+   }
+-  if (this->InitializationHelper == NULL)
++  if (this->InitializationHelper == nullptr)
+   {
+     vtkMPICommunicator* communicator = vtkMPICommunicator::New();
+     communicator->InitializeExternal(&comm);
+@@ -157,12 +184,12 @@
+     this->Controller = controller;
+     this->Controller->SetGlobalController(controller);
+     communicator->Delete();
+-    return this->Initialize();
++    return this->Initialize(workingDirectory);
+   }
+   return 1;
+ #else
+   static_cast<void>(&comm); // get rid of variable not used warning
+-  return this->Initialize();
++  return this->Initialize(workingDirectory);
+ #endif
+ }
+ 
+@@ -225,6 +252,13 @@
+       input->GetFieldData()->AddArray(catalystChannel);
+     }
+   }
++
++  std::string originalWorkingDirectory;
++  if (this->WorkingDirectory)
++  {
++    originalWorkingDirectory = vtksys::SystemTools::GetCurrentWorkingDirectory();
++    vtksys::SystemTools::ChangeDirectory(this->WorkingDirectory);
++  }
+   for (vtkCPProcessorInternals::PipelineListIterator iter = this->Internal->Pipelines.begin();
+        iter != this->Internal->Pipelines.end(); iter++)
+   {
+@@ -248,6 +282,10 @@
+       }
+     }
+   }
++  if (originalWorkingDirectory.empty() == false)
++  {
++    vtksys::SystemTools::ChangeDirectory(originalWorkingDirectory);
++  }
+   // we want to reset everything here to make sure that new information
+   // is properly passed in the next time.
+   dataDescription->ResetAll();
+@@ -259,7 +297,7 @@
+ {
+   if (this->Controller)
+   {
+-    this->Controller->SetGlobalController(NULL);
++    this->Controller->SetGlobalController(nullptr);
+     this->Controller->Finalize(1);
+     this->Controller->Delete();
+   }
+--- ParaView-v5.5.0/CoProcessing/Catalyst/vtkCPProcessor.h.orig	2018-04-06 22:03:33.000000000 +0200
++++ ParaView-v5.5.0/CoProcessing/Catalyst/vtkCPProcessor.h	2018-05-11 12:02:26.894772713 +0200
+@@ -76,14 +76,16 @@
+   virtual void RemoveAllPipelines();
+ 
+   /// Initialize the co-processor. Returns 1 if successful and 0
+-  /// otherwise.
+   /// otherwise. If Catalyst is built with MPI then Initialize()
+   /// can also be called with a specific MPI communicator if
+   /// MPI_COMM_WORLD isn't the proper one. Catalyst is initialized
+-  /// to use MPI_COMM_WORLD by default.
+-  virtual int Initialize();
++  /// to use MPI_COMM_WORLD by default. Both methods have an optional
++  /// workingDirectory argument which will set *WorkingDirectory* so
++  /// that files will be put relative to this directory.
++  virtual int Initialize(const char* workingDirectory = nullptr);
+ #ifndef __WRAP__
+-  virtual int Initialize(vtkMPICommunicatorOpaqueComm& comm);
++  virtual int Initialize(
++    vtkMPICommunicatorOpaqueComm& comm, const char* workingDirectory = nullptr);
+ #endif
+ 
+   /// The Catalyst input field data string array name. This array will
+@@ -111,6 +113,13 @@
+   /// implementation an opportunity to clean up, before it is destroyed.
+   virtual int Finalize();
+ 
++  /// Get the current working directory for outputting Catalyst files.
++  /// If not set then Catalyst output files will be relative to the
++  /// current working directory. This will not affect where Catalyst
++  /// looks for Python scripts. *WorkingDirectory* gets set through
++  /// the *Initialize()* methods.
++  vtkGetStringMacro(WorkingDirectory);
++
+ protected:
+   vtkCPProcessor();
+   virtual ~vtkCPProcessor();
+@@ -118,6 +127,11 @@
+   /// Create a new instance of the InitializationHelper.
+   virtual vtkObject* NewInitializationHelper();
+ 
++  /// Set the current working directory for outputting Catalyst files.
++  /// This is a protected method since simulation code adaptors should
++  /// set this through the *Initialize()* methods.
++  vtkSetStringMacro(WorkingDirectory);
++
+ private:
+   vtkCPProcessor(const vtkCPProcessor&) = delete;
+   void operator=(const vtkCPProcessor&) = delete;
+@@ -125,6 +139,7 @@
+   vtkCPProcessorInternals* Internal;
+   vtkObject* InitializationHelper;
+   static vtkMultiProcessController* Controller;
++  char* WorkingDirectory;
+ };
+ 
+ #endif
+--- ParaView-v5.5.0/CoProcessing/Catalyst/vtkCPXMLPWriterPipeline.cxx.orig	2018-04-06 22:03:33.000000000 +0200
++++ ParaView-v5.5.0/CoProcessing/Catalyst/vtkCPXMLPWriterPipeline.cxx	2018-05-11 12:02:26.894772713 +0200
+@@ -31,6 +31,7 @@
+ #include <vtkSmartPointer.h>
+ #include <vtkUnstructuredGrid.h>
+ 
++#include <algorithm>
+ #include <sstream>
+ #include <string>
+ 
+@@ -174,7 +175,7 @@
+ 
+   for (unsigned int i = 0; i < dataDescription->GetNumberOfInputDescriptions(); i++)
+   {
+-    const char* inputName = dataDescription->GetInputDescriptionName(i);
++    std::string inputName = dataDescription->GetInputDescriptionName(i);
+     vtkCPInputDataDescription* idd = dataDescription->GetInputDescription(i);
+     vtkDataObject* grid = idd->GetGrid();
+     if (grid == nullptr)
+@@ -206,6 +207,8 @@
+         vtkSMStringVectorProperty* fileName =
+           vtkSMStringVectorProperty::SafeDownCast(writer->GetProperty("FileName"));
+ 
++        // If we have a / in the channel name we take it out of the filename we're going to write to
++        inputName.erase(std::remove(inputName.begin(), inputName.end(), '/'), inputName.end());
+         std::ostringstream o;
+         if (this->Path.empty() == false)
+         {
+--- ParaView-v5.5.0/Wrapping/Python/paraview/coprocessing.py.orig	2018-04-06 22:03:33.000000000 +0200
++++ ParaView-v5.5.0/Wrapping/Python/paraview/coprocessing.py	2018-05-11 12:02:27.038772408 +0200
+@@ -11,22 +11,12 @@
+ from paraview.vtk.vtkPVVTKExtensionsCore import *
+ import math
+ 
+-# -----------------------------------------------------------------------------
+-def IsInModulo(timestep, frequencyArray):
+-    """
+-    Return True if the given timestep is in one of the provided frequency.
+-    This can be interpreted as follow::
+-
+-        isFM = IsInModulo(timestep, [2,3,7])
+-
+-    is similar to::
++# If the user created a filename in a location that doesn't exist by default we'll
++# make the directory for them. This can be changed though by setting createDirectoriesIfNeeded
++# to False.
++createDirectoriesIfNeeded = True
+ 
+-        isFM = (timestep % 2 == 0) or (timestep % 3 == 0) or (timestep % 7 == 0)
+-    """
+-    for frequency in frequencyArray:
+-        if frequency > 0 and (timestep % frequency == 0):
+-            return True
+-    return False
++# -----------------------------------------------------------------------------
+ 
+ class CoProcessor(object):
+     """Base class for co-processing Pipelines.
+@@ -68,6 +58,9 @@
+         self.__CinemaTracks = {}
+         self.__InitialFrequencies = {}
+         self.__PrintEnsightFormatString = False
++        self.__TimeStepToStartOutputAt=0
++        self.__ForceOutputAtFirstCall=False
++        self.__FirstTimeStepIndex = None
+ 
+     def SetPrintEnsightFormatString(self, enable):
+         """If outputting ExodusII files with the purpose of reading them into
+@@ -87,6 +80,17 @@
+                  "Incorrect argument type: %s, must be a dict" % type(frequencies))
+         self.__InitialFrequencies = frequencies
+ 
++    def SetInitialOutputOptions(self, timeStepToStartOutputAt, forceOutputAtFirstCall):
++        """Set the frequencies at which the pipeline needs to be updated.
++           Typically, this is called by the subclass once it has determined what
++           timesteps co-processing will be needed to be done.
++           frequencies is a map, with key->string name of for the simulation
++           input, and value is a list of frequencies.
++           """
++
++        self.__TimeStepToStartOutputAt=timeStepToStartOutputAt
++        self.__ForceOutputAtFirstCall=forceOutputAtFirstCall
++
+     def EnableLiveVisualization(self, enable, frequency = 1):
+         """Call this method to enable live-visualization. When enabled,
+         DoLiveVisualization() will communicate with ParaView server if possible
+@@ -115,7 +119,7 @@
+         # if this is a time step to do live then all of the inputs
+         # must be made available. note that we want the pipeline built
+         # before we do the actual first live connection.
+-        if self.__EnableLiveVisualization and timestep % self.__LiveVisualizationFrequency == 0 \
++        if self.__EnableLiveVisualization and self.NeedToOutput(timestep, self.__LiveVisualizationFrequency) \
+            and self.__LiveVisualizationLink:
+             if self.__LiveVisualizationLink.Initialize(servermanager.ActiveConnection.Session.GetSessionProxyManager()):
+                 num_inputs = datadescription.GetNumberOfInputDescriptions()
+@@ -132,13 +136,13 @@
+         # hasn't been set up yet). If we don't have live enabled
+         # we know that the output frequencies aren't changed and can
+         # just use the initial frequencies.
+-        if self.__InitialFrequencies or not self.__EnableLiveVisualization:
++        if self.__ForceOutputAtFirstCall or self.__InitialFrequencies or not self.__EnableLiveVisualization:
+             num_inputs = datadescription.GetNumberOfInputDescriptions()
+             for cc in range(num_inputs):
+                 input_name = datadescription.GetInputDescriptionName(cc)
+ 
+                 freqs = self.__InitialFrequencies.get(input_name, [])
+-                if self.__EnableLiveVisualization or ( self and IsInModulo(timestep, freqs) ):
++                if self.__EnableLiveVisualization or ( self and self.IsInModulo(timestep, freqs) ):
+                         datadescription.GetInputDescription(cc).AllFieldsOn()
+                         datadescription.GetInputDescription(cc).GenerateMeshOn()
+         else:
+@@ -149,15 +153,14 @@
+             for writer in self.__WritersList:
+                 frequency = writer.parameters.GetProperty(
+                     "WriteFrequency").GetElement(0)
+-                if (timestep % frequency) == 0 or \
+-                   datadescription.GetForceOutput() == True:
++                if self.NeedToOutput(timestep, frequency) or datadescription.GetForceOutput() == True:
+                     writerinputs = cpstate.locate_simulation_inputs(writer)
+                     for writerinput in writerinputs:
+                         datadescription.GetInputDescriptionByName(writerinput).AllFieldsOn()
+                         datadescription.GetInputDescriptionByName(writerinput).GenerateMeshOn()
+ 
+             for view in self.__ViewsList:
+-                if (view.cpFrequency and timestep % view.cpFrequency == 0) or \
++                if (view.cpFrequency and self.NeedToOutput(timestep, view.cpFrequency)) or \
+                    datadescription.GetForceOutput() == True:
+                     viewinputs = cpstate.locate_simulation_inputs_for_view(view)
+                     for viewinput in viewinputs:
+@@ -192,8 +195,7 @@
+         for writer in self.__WritersList:
+             frequency = writer.parameters.GetProperty(
+                 "WriteFrequency").GetElement(0)
+-            if (timestep % frequency) == 0 or \
+-                    datadescription.GetForceOutput() == True:
++            if self.NeedToOutput(timestep, frequency) or datadescription.GetForceOutput() == True:
+                 fileName = writer.parameters.GetProperty("FileName").GetElement(0)
+                 paddingamount = writer.parameters.GetProperty("PaddingAmount").GetElement(0)
+                 helperName = writer.GetXMLName()
+@@ -203,6 +205,23 @@
+                 else:
+                     ts = str(timestep).rjust(paddingamount, '0')
+                     writer.FileName = fileName.replace("%t", ts)
++                if '/' in writer.FileName and createDirectoriesIfNeeded:
++                    oktowrite = [1.]
++                    import vtk
++                    comm = vtk.vtkMultiProcessController.GetGlobalController()
++                    if comm.GetLocalProcessId() == 0:
++                        import os
++                        newDir = writer.FileName[0:writer.FileName.rfind('/')]
++                        try:
++                            os.makedirs(newDir)
++                        except OSError:
++                            if not os.path.isdir(newDir):
++                                print ("ERROR: Cannot make directory for", writer.FileName, ". No data will be written.")
++                                oktowrite[0] = 0.
++                    comm.Broadcast(oktowrite, 1, 0)
++                    if oktowrite[0] == 0:
++                        # we can't make the directory so no reason to update the pipeline
++                        return
+                 writer.UpdatePipeline(datadescription.GetTime())
+ 
+     def WriteImages(self, datadescription, rescale_lookuptable=False,
+@@ -240,7 +259,7 @@
+ 
+         cinema_dirs = []
+         for view in self.__ViewsList:
+-            if (view.cpFrequency and timestep % view.cpFrequency == 0) or \
++            if (view.cpFrequency and self.NeedToOutput(timestep, view.cpFrequency)) or \
+                datadescription.GetForceOutput() == True:
+                 fname = view.cpFileName
+                 ts = str(timestep).rjust(padding_amount, '0')
+@@ -267,6 +286,24 @@
+                     if dirname:
+                         cinema_dirs.append(dirname)
+                 else:
++                    if '/' in fname and createDirectoriesIfNeeded:
++                        oktowrite = [1.]
++                        import vtk
++                        comm = vtk.vtkMultiProcessController.GetGlobalController()
++                        if comm.GetLocalProcessId() == 0:
++                            import os
++                            newDir = fname[0:fname.rfind('/')]
++                            try:
++                                os.makedirs(newDir)
++                            except OSError:
++                                if not os.path.isdir(newDir):
++                                    print ("ERROR: Cannot make directory for", fname, ". No image will be output.")
++                                    oktowrite[0] = 0.
++                        comm.Broadcast(oktowrite, 1, 0)
++                        if oktowrite[0] == 0:
++                            # we can't make the directory so no reason to update the pipeline
++                            return
++
+                     if image_quality is None and fname.endswith('png'):
+                         # for png quality = 0 means no compression. compression can be a potentially
+                         # very costly serial operation on process 0
+@@ -307,7 +344,7 @@
+ 
+ 
+         timeStep = datadescription.GetTimeStep()
+-        if self.__EnableLiveVisualization and timeStep % self.__LiveVisualizationFrequency == 0:
++        if self.__EnableLiveVisualization and self.NeedToOutput(timeStep, self.__LiveVisualizationFrequency):
+             if not self.__LiveVisualizationLink.Initialize(servermanager.ActiveConnection.Session.GetSessionProxyManager()):
+                 return
+ 
+@@ -412,7 +449,7 @@
+         """
+         controller = servermanager.ParaViewPipelineController()
+         # assume that a client only proxy with the same name as a writer
+-        # is available in "insitu_writer_paramters"
++        # is available in "insitu_writer_parameters"
+ 
+         # Since coprocessor sometimes pass writer as a custom object and not
+         # a proxy, we need to handle that. Just creating any arbitrary writer
+@@ -666,3 +703,42 @@
+         #restore what we showed
+         pv_introspect.restore_visibility(pxystate)
+         return os.path.basename(vfname)
++
++    def IsInModulo(self, timestep, frequencies):
++        """
++        Return True if the given timestep is in one of the provided frequency.
++        This can be interpreted as follow::
++
++        isFM = IsInModulo(timestep-timeStepToStartOutputAt, [2,3,7])
++
++        is similar to::
++
++        isFM = (timestep-timeStepToStartOutputAt % 2 == 0) or (timestep-timeStepToStartOutputAt % 3 == 0) or (timestep-timeStepToStartOutputAt % 7 == 0)
++
++        The timeStepToStartOutputAt is the first timestep that will potentially be output.
++        """
++        if timestep < self.__TimeStepToStartOutputAt and not self.__ForceOutputAtFirstCall:
++            return False
++        for frequency in frequencies:
++            if frequency > 0 and self.NeedToOutput(timestep, frequency):
++                return True
++
++        return False
++
++
++    def NeedToOutput(self, timestep, frequency):
++        """
++        Return True if we need to output based on the input timestep and frequency. Checks based
++        __FirstTimeStepIndex, __FirstTimeStepIndex, __ForceOutputAtFirstCall and __TimeStepToStartOutputAt
++        member variables.
++        """
++        if self.__FirstTimeStepIndex == None:
++            self.__FirstTimeStepIndex = timestep
++
++        if self.__ForceOutputAtFirstCall and self.__FirstTimeStepIndex == timestep:
++            return True
++
++        if self.__TimeStepToStartOutputAt <= timestep and (timestep-self.__TimeStepToStartOutputAt) % frequency == 0:
++            return True
++
++        return False

--- a/recipes/paraview/v1/gh200/repo/packages/paraview/vtkm-findmpi-downstream.patch
+++ b/recipes/paraview/v1/gh200/repo/packages/paraview/vtkm-findmpi-downstream.patch
@@ -1,0 +1,51 @@
+From 5bf0eff1563820d7c997649da372ab003fd4af81 Mon Sep 17 00:00:00 2001
+From: Chuck Atkins <chuck.atkins@kitware.com>
+Date: Mon, 15 Feb 2021 13:59:50 -0500
+Subject: [PATCH] CMake: Fix FindMPI getting consumed by newer CMake versions
+
+---
+ CMake/patches/FindMPI.cmake | 11 +++++++++++
+ CMakeLists.txt              |  7 ++++++-
+ 2 files changed, 17 insertions(+), 1 deletion(-)
+ create mode 100644 CMake/patches/FindMPI.cmake
+
+diff --git a/VTK/ThirdParty/vtkm/vtkvtkm/vtk-m/CMake/patches/FindMPI.cmake b/VTK/ThirdParty/vtkm/vtkvtkm/vtk-m/CMake/patches/FindMPI.cmake
+new file mode 100644
+index 000000000..a4ed44f04
+--- /dev/null
++++ b/VTK/ThirdParty/vtkm/vtkvtkm/vtk-m/CMake/patches/FindMPI.cmake
+@@ -0,0 +1,11 @@
++#------------------------------------------------------------------------------#
++# Distributed under the OSI-approved Apache License, Version 2.0.  See
++# accompanying file Copyright.txt for details.
++#------------------------------------------------------------------------------#
++
++# This module is already included in new versions of CMake
++if(CMAKE_VERSION VERSION_LESS 3.15)
++  include(${CMAKE_CURRENT_LIST_DIR}/3.15/FindMPI.cmake)
++else()
++  include(${CMAKE_ROOT}/Modules/FindMPI.cmake)
++endif()
+diff --git a/VTK/ThirdParty/vtkm/vtkvtkm/vtk-m/CMakeLists.txt b/VTK/ThirdParty/vtkm/vtkvtkm/vtk-m/CMakeLists.txt
+index e907495f3..fa464ab8d 100644
+--- a/VTK/ThirdParty/vtkm/vtkvtkm/vtk-m/CMakeLists.txt
++++ b/VTK/ThirdParty/vtkm/vtkvtkm/vtk-m/CMakeLists.txt
+@@ -277,9 +277,14 @@ if(NOT VTKm_INSTALL_ONLY_LIBRARIES)
+     FILES
+       ${VTKm_SOURCE_DIR}/CMake/VTKmCMakeBackports.cmake
+       ${VTKm_SOURCE_DIR}/CMake/FindTBB.cmake
+-      ${VTKm_SOURCE_DIR}/CMake/patches/3.15/FindMPI.cmake
++      ${VTKm_SOURCE_DIR}/CMake/patches/FindMPI.cmake
+     DESTINATION ${VTKm_INSTALL_CMAKE_MODULE_DIR}
+     )
++  install(
++    FILES
++      ${VTKm_SOURCE_DIR}/CMake/patches/3.15/FindMPI.cmake
++    DESTINATION ${VTKm_INSTALL_CMAKE_MODULE_DIR}/3.15
++    )
+ 
+   # Install support files.
+   install(
+-- 
+2.24.2
+

--- a/recipes/paraview/v1/gh200/repo/packages/paraview/xlc-compilation-pv590.patch
+++ b/recipes/paraview/v1/gh200/repo/packages/paraview/xlc-compilation-pv590.patch
@@ -1,0 +1,39 @@
+diff --git a/VTK/Common/DataModel/vtkStaticCellLinksTemplate.txx b/VTK/Common/DataModel/vtkStaticCellLinksTemplate.txx
+index 514c0ee..66edca2 100644
+--- a/VTK/Common/DataModel/vtkStaticCellLinksTemplate.txx
++++ b/VTK/Common/DataModel/vtkStaticCellLinksTemplate.txx
+@@ -356,7 +356,7 @@ void vtkStaticCellLinksTemplate<TIds>::ThreadedBuildLinks(
+
+   // Create an array of atomics with initial count=0. This will keep
+   // track of point uses. Count them in parallel.
+-  std::atomic<TIds>* counts = new std::atomic<TIds>[numPts] {};
++  std::atomic<TIds>* counts = new std::atomic<TIds>[numPts] ();
+   CountUses<TIds> count(cellArray, counts);
+   vtkSMPTools::For(0, numCells, count);
+
+diff --git a/VTK/Filters/Core/vtkBinnedDecimation.cxx b/VTK/Filters/Core/vtkBinnedDecimation.cxx
+index 0736c56..8403908 100644
+--- a/VTK/Filters/Core/vtkBinnedDecimation.cxx
++++ b/VTK/Filters/Core/vtkBinnedDecimation.cxx
+@@ -632,7 +632,7 @@ void BinPointsDecimate(int genMode, vtkIdType numPts, PointsT* pts, vtkPointData
+   // is a problem because a ptId can == zero; as a workaround, we'll
+   // initially use negative ids, and convert to positive ids in the
+   // final composition.
+-  std::atomic<TIds>* ptMap = new std::atomic<TIds>[numBins] {};
++  std::atomic<TIds>* ptMap = new std::atomic<TIds>[numBins] ();
+
+   // Is the triangle output? And eventually the offset into the output cell array.
+   TIds* triMap = new TIds[numTris + 1];
+diff --git a/VTK/Filters/Core/vtkWindowedSincPolyDataFilter.cxx b/VTK/Filters/Core/vtkWindowedSincPolyDataFilter.cxx
+index 15e47a1..7baef33 100644
+--- a/VTK/Filters/Core/vtkWindowedSincPolyDataFilter.cxx
++++ b/VTK/Filters/Core/vtkWindowedSincPolyDataFilter.cxx
+@@ -348,7 +348,7 @@ struct PointConnectivity : PointConnectivityBase
+     // accommodate more smoothing edges (although after a certain point,
+     // additional edges make little difference, especially at the cost of
+     // memory and speed).
+-    this->Offsets = new std::atomic<TIds>[this->NumPts + 1] {}; // Initialized to zero
++    this->Offsets = new std::atomic<TIds>[this->NumPts + 1] (); // Initialized to zero
+     this->Edges = nullptr;                                      // initially until constructed
+     this->EdgeCounts = new EDGE_COUNT_TYPE[this->NumPts];       // values set later
+   }

--- a/recipes/paraview/v1/readme.md
+++ b/recipes/paraview/v1/readme.md
@@ -1,0 +1,11 @@
+# ICON PE
+
+A programming environment for development of both the Fortran+OpenACC and DSL versions of ICON.
+
+## Custom spack packages
+
+### netcdf-c
+
+The netcdf-c package adds a `logging` variant that sets the `--enable-logging` autotools flag.
+
+A Spack PR will be opend to add this feature to the upstream package once this feature has been validated.


### PR DESCRIPTION
This PR is a work in progress to get Paraview built for ICON. I'm not sure it is the most maintainable solution (no reference to icon-wcp, just copied the folder), in case anyone has any suggestion, please tell me.

TODO:
- [x] https://github.com/eth-cscs/alps-cluster-config/pull/7
- [x] Publish newly created CDI package in spack (https://github.com/spack/spack/pull/44222)
- [x] Fix `paraview` workaround about `cuda_arch` https://github.com/spack/spack/pull/44243
- [x] Publish `libcatalyst` package fix in spack (https://github.com/spack/spack/pull/44224)

Main features enabled in Paraview:
- mpi
- fortran
- python
- tbb
- nvindex
- CDI
- raytracing
- libcatalyst

`paraview@5.12.0~adios2~advanced_debug~catalyst+cdi+cuda+development_files+egl~examples~eyedomelighting+fortran+hdf5~ipo+kits+libcatalyst+mpi+nvindex+opengl2~openpmd~osmesa~pagosa+python~qt+raytracing~rocm+shared+tbb~visitbridge build_edition=canonical build_system=cmake build_type=Release cuda_arch=90 generator=ninja patches=02253c7,f45d9e9 use_vtkm=default`

FYI @jfavre