### PR TITLE
Document how to use uenvs as upstream Spack instances

### DIFF
--- a/docs/uenv-compilation-spack.md
+++ b/docs/uenv-compilation-spack.md
@@ -148,7 +148,7 @@ ninja -j 32
 ## Known Limitations
 
 !!! warning
-    Swapping the upstream [Spack] instance by loading different uenvs might lead to a corruption of the [Spack] database. If this happens, you can uninstall everything from your local [Spack] instance with `spack uninstall --all` and clean up with `spack clean --all`.
+    Swapping the upstream [Spack] instance by loading different uenvs might lead to surprising inconsistencies in the [Spack] database. If this happens, you can uninstall everything from your local [Spack] instance with `spack uninstall --all` and clean up with `spack clean --all`.
 
 [Chaining Spack Installations]: https://spack.readthedocs.io/en/latest/chain.html
 [CP2K]: https://eth-cscs.github.io/alps-uenv/uenv-cp2k/

--- a/docs/uenv-compilation-spack.md
+++ b/docs/uenv-compilation-spack.md
@@ -1,6 +1,6 @@
 # Using uenvs as upstream Spack instances
 
-User-environments (uenvs) are built with [Spack] using the [Stackinator] tool. Therefore, an `uenv` is tightly copuled with [Spack] and can be used as an upstream [Spack] instance (see [Chaining Spack Installations] for more details).
+User-environments (uenvs) are built with [Spack] using the [Stackinator] tool. Therefore, a `uenv` is tightly coupled with [Spack] and can be used as an upstream [Spack] instance (see [Chaining Spack Installations] for more details).
 
 !!! note
     While this guide tries to explain everything step-by-step, it might be difficult to follow without any knowledge of [Spack]. Please have a look at [Spack Basic Usage] for a short introduction to [Spack].
@@ -13,7 +13,7 @@ This guide explains a _developer workflow_ allowing to either build your own pac
     This guide assumes that you have a local installation of [Spack]. If you don't have [Spack] installed, follow [Spack Getting Started].
 
 !!! warning
-    Avoid installing [Spack] on `HOME`. Packages are installaed within the `spack/` folder, and you might quickly run out of space.
+    Avoid installing [Spack] on `HOME`. Packages are installed within the `spack/` folder, and you might quickly run out of space.
 
 ## Example: CP2K
 
@@ -51,7 +51,7 @@ Let's assume we want to have a version of [CP2K] what uses the COSMA library for
 cp2k@2024.1 +cuda cuda_arch=80 +cosma ^cosma +gpu_direct
 ```
 
-COSMA is not availabe in the uenv described above since it is not a dependency needed by `cp2k@2024.1 +cuda cuda_arch=80`. 
+COSMA is not available in the uenv described above since it is not a dependency needed by `cp2k@2024.1 +cuda cuda_arch=80`. 
 
 ### Spack Environment
 
@@ -86,7 +86,7 @@ After defining the environment above, we can concretize it:
 spack -e SPACK_ENV_FOLDER concretize -f
 ```
 
-The result of the concretization will be printed on screen. Packages starting with `[+]` are packages that will be freshly installed in your local [Spack] instance. Packages marked ad `[e]` (external) are packages taken directly from the uenv (which we are using as upstream [Spack] instance). You should see many packages marked as `[e]`, which are being re-used from the uenv. This will greatly speed up compilation, since [Spack] will have to build only a small subset of packages.
+The result of the concretization will be printed on screen. Packages starting with `[+]` are packages that will be freshly installed in your local [Spack] instance. Packages marked as `[e]` (external) are packages taken directly from the uenv (which we are using as upstream [Spack] instance). You should see many packages marked as `[e]`, which are being re-used from the uenv. This will greatly speed up compilation, since [Spack] will have to build only a small subset of packages.
 
 You can finally build everything in the concretized environment:
 
@@ -106,7 +106,7 @@ We assume again that COSMA is not present in the provided uenv.
 
 ### Spack Environment and Building Dependencies
 
-As described above, you can define a [Spack environment] describing the version of the package you want to build and the contraint on the dependencies. After concretizing the environment with
+As described above, you can define a [Spack environment] describing the version of the package you want to build and the constraint on the dependencies. After concretizing the environment with
 
 ```bash
 spack -e SPACK_ENV_FOLDER concretize -f

--- a/docs/uenv-compilation-spack.md
+++ b/docs/uenv-compilation-spack.md
@@ -38,14 +38,14 @@ This [spec] defines a build of [Quantum ESPRESSO] version `7.3.1` using the `nvh
 
 ## Set uenv as upstream Spack instance
 
-Activate the uenv. Here we assume the uenv described above is called `quantumespresso/v7.3.1` and it is already deployed:
+Here we assume the uenv described above is called `quantumespresso/v7.3.1` and it is already deployed. You can therefore pull the `quantumespresso/v7.3.1` image and start the uenv as follows:
 
 ```bash
 uenv image pull quantumespresso/v7.3.1
 uenv start quantumespresso/v7.3.1
 ```
 
-With the uenv active, you can now tell our local [Spack] instance to use the uenv as an upstream [Spack] instance (see [Chaining Spack Installations] for more details):
+With the uenv active, you can now tell your local [Spack] instance to use the uenv as an upstream [Spack] instance (see [Chaining Spack Installations] for more details):
 
 ```bash
 export SPACK_SYSTEM_CONFIG_PATH=/user-environment/config/

--- a/docs/uenv-compilation-spack.md
+++ b/docs/uenv-compilation-spack.md
@@ -13,7 +13,10 @@ This guide explains a _developer workflow_ allowing to either build your own pac
     This guide assumes that you have a local installation of [Spack]. If you don't have [Spack] installed, follow [Spack Getting Started].
 
 !!! warning
-    Avoid installing [Spack] on `HOME`. Packages are installed within the `spack/` folder, and you might quickly run out of space.
+    Avoid installing [Spack] on `HOME`. Packages are installed within the `spack/` folder, and you might quickly run out of space. Use `SCRATCH` instead.
+
+!!! danger
+    The recommendation to use `SCRATCH` to install your local [Spack] instance(s) might change in the future. Make sure you are aware of our `SCRATCH` cleaning policy. 
 
 ## Example: CP2K
 
@@ -86,7 +89,9 @@ After defining the environment above, we can concretize it:
 spack -e SPACK_ENV_FOLDER concretize -f
 ```
 
-The result of the concretization will be printed on screen. Packages starting with `[+]` are packages that will be freshly installed in your local [Spack] instance. Packages marked as `[e]` (external) are packages taken directly from the uenv (which we are using as upstream [Spack] instance). You should see many packages marked as `[e]`, which are being re-used from the uenv. This will greatly speed up compilation, since [Spack] will have to build only a small subset of packages.
+The result of the concretization will be printed on screen. Packages marked with ` - ` are packages that will be freshly installed in your local [Spack] instance. Packages marked as `[^]` (upstream) are packages taken directly from the uenv (which we are using as upstream [Spack] instance). You should see many packages marked as `[^]`, which are being re-used from the uenv. `[e]` (external) are external packages that are already installed in the system (and are defined in the system configuration of the system for which the uenv is built). Finally, packages marked as `[+]` are packages that are already installed in your local [Spack] instances.
+
+Using the uenv as an upstream [Spack] instance will greatly speed up compilation, since [Spack] will have to build only a small subset of packages.
 
 You can finally build everything in the concretized environment:
 
@@ -148,7 +153,7 @@ ninja -j 32
 ## Known Limitations
 
 !!! warning
-    Swapping the upstream [Spack] instance by loading different uenvs might lead to surprising inconsistencies in the [Spack] database. If this happens, you can uninstall everything from your local [Spack] instance with `spack uninstall --all` and clean up with `spack clean --all`.
+    Swapping the upstream [Spack] instance by loading different uenvs might lead to surprising inconsistencies in the [Spack] database. If this happens, you can uninstall everything from your local [Spack] instance with `spack uninstall --all` and clean up with `spack clean --all`. To avoid this problem, you can also work with multiple local [Spack] instances (one for each uenv).
 
 [Chaining Spack Installations]: https://spack.readthedocs.io/en/latest/chain.html
 [CP2K]: https://eth-cscs.github.io/alps-uenv/uenv-cp2k/

--- a/docs/uenv-compilation-spack.md
+++ b/docs/uenv-compilation-spack.md
@@ -1,0 +1,163 @@
+# Using uenvs as upstream Spack instances
+
+User-environments (uenvs) are built with [Spack] using the [Stackinator] tool. Therefore, an `uenv` is tightly copuled with [Spack] and can be used as an upstream [Spack] instance (see [Chaining Spack Installations] for more details).
+
+!!! note
+    While this guide tries to explain everything step-by-step, it might be difficult to follow without any knowledge of [Spack]. Please have a look at [Spack Basic Usage] for a short introduction to [Spack].
+
+The uenv of a supported application contains all the dependencies to build the software with a particular configuration. In [Spack], such configuration is defined by a [spec] (see [Spack Basic Usage] for more details). Most uenvs already provide modules or [Spack Filesystem Views] which allow to manually build the same configuration. However, it is possible that you want to build or develop an application with a different configuration. To avoid re-building the whole uenv, you can re-use what is already there and build your new configuration using [Spack]. 
+
+This guide explains a _developer workflow_ allowing to either build your own package with [Spack], or use [Spack] to build all the dependencies and provide a build environment for the package.
+
+!!! note
+    This guide assumes that you have a local installation of [Spack]. If you don't have [Spack] installed, follow [Spack Getting Started].
+
+!!! warning
+    Avoid installing [Spack] on `HOME`. Packages are installaed within the `spack/` folder, and you might quickly run out of space.
+
+## Example: CP2K
+
+As an example, we will consider [CP2K] as the application we want to develop. While the uenv for [CP2K] we provide is rather complete, let's assume for simplicity that the provided configuration is very bare bone:
+
+```
+cp2k@2024.1 +cuda cuda_arch=80
+```
+
+This [spec] defines a build of [CP2K] version `2024.1` with CUDA acceleration. All other dependencies and features are defined by the default values in the [CP2K Spack package].
+
+## Set uenv as upstream Spack instance
+
+Activate the uenv. Here we assume the uenv described above is called `cp2k/2024.1` and it is already deployed:
+
+```bash
+uenv image pull cp2k/2024.1
+uenv start cp2k/2024.1
+```
+
+With the uenv active, we can now tell our local [Spack] instance to use the uenv as an upstream [Spack] instance (see [Chaining Spack Installations] for more details):
+
+```bash
+export SPACK_SYSTEM_CONFIG_PATH=/user-environment/config/
+```
+
+!!! note
+    We assumed here that the uenv is mounted in the standard location `/user-environment/`. If it is mounted in a non-standard location, adjust the previous command accordingly.
+
+## Building your own version 
+
+Let's assume we want to have a version of [CP2K] what uses the COSMA library for communication-optimal matrix multiplication with GPU-aware MPI:
+
+```
+cp2k@2024.1 +cuda cuda_arch=80 +cosma ^cosma +gpu_direct
+```
+
+COSMA is not availabe in the uenv described above since it is not a dependency needed by `cp2k@2024.1 +cuda cuda_arch=80`. 
+
+### Spack Environment
+
+To make things clean and reproducible, we use [Spack Environments] do describe what we want to build. To define a [Spack environment] we create the following file in a folder (hereafter referred to as `SPACK_ENV_FOLDER`):
+
+```yaml
+spack:
+  specs:
+  - cp2k@2024.1 +cosma
+  packages:
+    all:
+      prefer:
+        - +cuda cuda_arch=80
+    cosma:
+      require:
+        - +gpu_direct
+  view: false
+  concretizer:
+    unify: true
+```
+
+`packages:all:prefer` indicates that we want the `+cuda` variant active for all packages that have it. The `require` clause is stronger, and we use it for a specific package, COSMA, to make sure the `+gpu_direct` variant (GPU-aware MPI) is enabled (this is a constraint we want to enforce on the COSMA dependency). 
+
+!!! note
+    It is good practice to have a single root [spec] in an environment, and to define constraint on all packages or specific dependencies in the `packages:` field.
+
+### Building
+
+After defining the environment above, we can concretize it:
+
+```bash
+spack -e SPACK_ENV_FOLDER concretize -f
+```
+
+The result of the concretization will be printed on screen. Packages starting with `[+]` are packages that will be freshly installed in your local [Spack] instance. Packages marked ad `[e]` (external) are packages taken directly from the uenv (which we are using as upstream [Spack] instance). You should see many packages marked as `[e]`, which are being re-used from the uenv. This will greatly speed up compilation, since [Spack] will have to build only a small subset of packages.
+
+You can finally build everything in the concretized environment:
+
+```bash
+spack -e SPACK_ENV_FOLDER install
+```
+
+## Developing with Spack
+
+In addition to wanting to build a different configuration of a package as described above, you might want to build your own software from source. Let's assume we want to develop [CP2K] with the COSMA library as a dependency:
+
+```
+cp2k@2024.1 +cuda cuda_arch=80 +cosma ^cosma +gpu_direct
+```
+
+We assume again that COSMA is not present in the provided uenv.
+
+### Spack Environment and Building Dependencies
+
+As described above, you can define a [Spack environment] describing the version of the package you want to build and the contraint on the dependencies. After concretizing the environment with
+
+```bash
+spack -e SPACK_ENV_FOLDER concretize -f
+```
+
+we can tell [Spack] to only install the dependencies, since we want to build the root [spec] manually:
+
+```bash
+spack -e SPACK_ENV_FOLDER install --only=dependencies
+```
+
+### Building the root spec manually
+
+Finally, we are ready to build the root [spec] manually. With [Spack] you can get a shell within the build environment as follows:
+
+```bash
+spack -e SPACK_ENV_FOLDER build-env cp2k -- bash
+```
+
+where `cp2k` denotes the root [spec]. Since there is only one such [spec], there is no need to explicitly write out the version nor the variants.
+
+Within the build environment, the software can be built using the provided build system. CP2K uses CMake, therefore we can simply do the following:
+
+```bash
+# In CP2K repository root folder
+
+mkdir build && cd build
+
+cmake \
+    -GNinja
+    -DCP2K_USE_COSMA=ON \
+    -DCP2K_USE_ACCEL=CUDA \
+    -DCP2K_WITH_GPU=A100 \
+    ..
+
+ninja -j 32
+```
+
+## Known Limitations
+
+!!! warning
+    Swapping the upstream [Spack] instance by loading different uenvs might lead to a corruption of the [Spack] database. If this happens, you can uninstall everything from your local [Spack] instance with `spack uninstall --all` and clean up with `spack clean --all`.
+
+[Chaining Spack Installations]: https://spack.readthedocs.io/en/latest/chain.html
+[CP2K]: https://eth-cscs.github.io/alps-uenv/uenv-cp2k/
+[CP2K Spack package]: https://packages.spack.io/package.html?name=cp2k
+[Spack]: https://spack.readthedocs.io/en/latest/
+[Spack Basic Usage]: https://spack.readthedocs.io/en/latest/basic_usage.html
+[Spack Environments]: https://spack.readthedocs.io/en/latest/environments.html
+[Spack environment]: https://spack.readthedocs.io/en/latest/environments.html
+[Spack Filesystem Views]: https://spack.readthedocs.io/en/latest/environments.html#filesystem-views
+[Spack Getting Started]: https://spack.readthedocs.io/en/latest/getting_started.html
+[spec]: https://spack.readthedocs.io/en/latest/basic_usage.html#sec-specs
+[Stackinator]: https://eth-cscs.github.io/stackinator/

--- a/docs/uenv-compilation-spack.md
+++ b/docs/uenv-compilation-spack.md
@@ -1,6 +1,6 @@
 # Using uenvs as upstream Spack instances
 
-User-environments (uenvs) are built with [Spack] using the [Stackinator] tool. Therefore, a `uenv` is tightly coupled with [Spack] and can be used as an upstream [Spack] instance (see [Chaining Spack Installations] for more details).
+User-environments (uenvs) are built with [Spack] using the [Stackinator] tool. Therefore, a uenv is tightly coupled with [Spack] and can be used as an upstream [Spack] instance (see [Chaining Spack Installations] for more details).
 
 !!! note
     While this guide tries to explain everything step-by-step, it might be difficult to follow without any knowledge of [Spack]. Please have a look at [Spack Basic Usage] for a short introduction to [Spack].
@@ -11,6 +11,14 @@ This guide explains a _developer workflow_ allowing to either build your own pac
 
 !!! note
     This guide assumes that you have a local installation of [Spack]. If you don't have [Spack] installed, follow [Spack Getting Started].
+
+!!! tip
+    To avoid compatibility issues, try to match the version of your local [Spack] instance with the version of [Spack] of the uenv. You can use the following command to clone the same [Spack] version used by the uenv:
+    ```bash
+    git clone \
+        -b $(jq -r .spack.commit /user-environment/meta/configure.json) \
+        $(jq -r .spack.repo /user-environment/meta/configure.json) $SCRATCH/spack
+    ```
 
 !!! warning
     Avoid installing [Spack] on `HOME`. Packages are installed within the `spack/` folder, and you might quickly run out of space. Use `SCRATCH` instead.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,8 @@ nav:
     - 'linaro-forge': uenv-linaro-forge.md
   - 'packaging':
     - 'tutorial: application': pkg-application-tutorial.md
+  - 'Compilation':
+    - 'uenv and Spack': uenv-compilation-spack.md
 theme:
   name: material
   features:


### PR DESCRIPTION
Draft for a documentation page explaining how to use user environments as upstream Spack instances. I think many people at CSCS use this or a similar workflow for development, so it might be useful for the end users too.

Feedback and suggestions on how to improve it very welcome! This is a rough initial draft to get the conversation started.