### PR TITLE
CP2K 2024.1 (GH200): fix develop build for COSTA

### DIFF
--- a/recipes/cp2k/2024.1/gh200/repo/packages/costa/package.py
+++ b/recipes/cp2k/2024.1/gh200/repo/packages/costa/package.py
@@ -42,6 +42,8 @@ class Costa(CMakePackage):
     depends_on("cxxopts", when="+tests")
     depends_on("semiprof", when="+profiling")
 
+    patch("mpi-view.patch")
+
     def url_for_version(self, version):
         if version == Version("2.0"):
             return "https://github.com/eth-cscs/COSTA/releases/download/v{0}/COSTA-v{1}.tar.gz".format(


### PR DESCRIPTION
A patch was added in #95 for `COSTA` and `COSMA`, but it was only applied to `COSMA`. This prevented to build with `-DCP2K_USE_COSMA=ON` from an view. This PR actually applies the provided patch.

This issue was likely not spotted because of a typo in the CMake command I used, fixed in #106.

The patches have been contributed upstream:
* https://github.com/eth-cscs/COSMA/pull/144
* https://github.com/eth-cscs/COSTA/pull/22

@bcumming I tested locally, but I'd like to test the CI-built image before deploying.