### PR TITLE
Mch xpmem gcc

### DIFF
--- a/recipes/mch/v6/environments.yaml
+++ b/recipes/mch/v6/environments.yaml
@@ -61,6 +61,7 @@ prgenv-nvidia:
   - zlib%gcc
   - nco@5.0.1%gcc
   - cdo@2.0.5%gcc
+  - xpmem%gcc
   variants:
   - cuda_arch=80
   - +mpi


### PR DESCRIPTION
Adding `xpmem%gcc` to the `prgenv-nvidia` environment to fix a concretization issue