### PR TITLE
Small fix to NAMD documentation

### DIFF
--- a/docs/uenv-namd.md
+++ b/docs/uenv-namd.md
@@ -20,7 +20,7 @@ The [NAMD] `uenv` provides all the dependencies required to build [NAMD] from so
 
 ```bash
 # Start uenv and load develop view
-uenv start namd.squashfs
+uenv start <NAMD_UENV>
 uenv view develop
 
 # cd to NAMD source directory


### PR DESCRIPTION
Try to make it clearer that the user should specify the UENV name. Hopefully avoids tickets from copy-paste as [SD-61793](https://jira.cscs.ch/browse/SD-61793).