### PR TITLE
prgenv-gnu: add +hl variant to hdf5

### DIFF
--- a/recipes/prgenv-gnu/24.7/gh200/environments.yaml
+++ b/recipes/prgenv-gnu/24.7/gh200/environments.yaml
@@ -12,7 +12,7 @@ gcc-env:
   - cuda@12.4
   - fftw
   - fmt
-  - hdf5
+  - hdf5+hl
   - libtree
   - meson
   - nccl

--- a/recipes/prgenv-gnu/24.7/mc/environments.yaml
+++ b/recipes/prgenv-gnu/24.7/mc/environments.yaml
@@ -10,7 +10,7 @@ gcc-env:
   - cmake
   - fftw
   - fmt
-  - hdf5
+  - hdf5+hl
   - ninja@1.11
   - openblas threads=openmp
   - python@3.12


### PR DESCRIPTION
The +hl variant enables the "high level" interface for hdf5, which is required by some packages.