### PR TITLE
NAMD 3.0 (GH200)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -133,6 +133,12 @@ uenvs:
         santis: [gh200]
         todi: [gh200]
       develop: False
+    "3.0":
+      recipes:
+        gh200: 3.0/gh200
+      deploy:
+        todi: [gh200]
+      develop: False
   netcdf-tools:
     "2024":
       recipes:

--- a/recipes/namd/3.0/gh200/compilers.yaml
+++ b/recipes/namd/3.0/gh200/compilers.yaml
@@ -1,0 +1,5 @@
+bootstrap:
+  spec: gcc@12
+gcc:
+  specs:
+  - gcc@12

--- a/recipes/namd/3.0/gh200/compilers.yaml
+++ b/recipes/namd/3.0/gh200/compilers.yaml
@@ -2,4 +2,4 @@ bootstrap:
   spec: gcc@12
 gcc:
   specs:
-  - gcc@12
+  - gcc@12.3.0

--- a/recipes/namd/3.0/gh200/config.yaml
+++ b/recipes/namd/3.0/gh200/config.yaml
@@ -1,0 +1,7 @@
+name: namd
+description: "NAMD: Scalable Molecular Dynamics" 
+store: /user-environment
+spack:
+  repo: https://github.com/spack/spack.git
+  commit: v0.22.0
+modules: True

--- a/recipes/namd/3.0/gh200/environments.yaml
+++ b/recipes/namd/3.0/gh200/environments.yaml
@@ -1,10 +1,10 @@
 namd-single-node:
   compiler:
   - toolchain: gcc
-    spec: gcc@12
+    spec: gcc@12.3.0
   unify: true
   specs:
-  - cuda@12
+  - cuda@12.4.0
   - fftw@3.3.10 +openmp ~mpi
   - tcl@8.5
   - charmpp@=8.0.0 backend=multicore +production +tracing

--- a/recipes/namd/3.0/gh200/environments.yaml
+++ b/recipes/namd/3.0/gh200/environments.yaml
@@ -1,0 +1,17 @@
+namd-single-node:
+  compiler:
+  - toolchain: gcc
+    spec: gcc@12
+  unify: true
+  specs:
+  - cuda@12
+  - fftw@3.3.10 +openmp ~mpi
+  - tcl@8.5
+  - charmpp@=8.0.0 backend=multicore +production +tracing
+  - namd@=3.0 +cuda cuda_arch=90 +single_node_gpu
+  views:
+    develop-single-node:
+      link: roots
+      exclude: ["namd"]
+    namd-single-node:
+      link: roots

--- a/recipes/namd/3.0/gh200/modules.yaml
+++ b/recipes/namd/3.0/gh200/modules.yaml
@@ -1,0 +1,25 @@
+modules:
+  prefix_inspections:
+    bin:
+      - PATH
+    lib:
+      - LD_LIBRARY_PATH
+    lib64:
+      - LD_LIBRARY_PATH
+
+  default:
+    arch_folder: false
+    roots:
+      tcl: /user-environment/modules
+    tcl:
+      all:
+        autoload: none
+      hash_length: 0
+      exclude_implicits: true
+      exclude: ['%gcc@7.5.0', 'gcc %gcc@7.5.0']
+      projections:
+        all: '{name}/{version}'
+        namd+single_node_gpu: '{name}-single-node/{version}'
+        fftw~mpi: '{name}-no-mpi/{version}'
+        charmpp backend=multicore: '{name}-multicore/{version}'
+        charmpp backend=ofi : '{name}-ofi/{version}'

--- a/recipes/namd/3.0/gh200/pre-install
+++ b/recipes/namd/3.0/gh200/pre-install
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -u
+
+namd_version=3.0
+namd=NAMD_${namd_version}_Source.tar.gz 
+
+username=$CSCS_REGISTRY_USERNAME
+password=$CSCS_REGISTRY_PASSWORD
+
+curl -u ${username}:${password} https://jfrog.svc.cscs.ch/artifactory/uenv-sources/namd/${namd} --output {{ env.build }}/environments/${namd}
+
+sha256sum {{ env.build }}/environments/${namd}
+
+

--- a/recipes/namd/3.0/gh200/repo/packages/charmpp/charm_6.7.1_aocc.patch
+++ b/recipes/namd/3.0/gh200/repo/packages/charmpp/charm_6.7.1_aocc.patch
@@ -1,0 +1,188 @@
+diff -bur charm-6.7.1/src/arch/mpi-linux-x86_64/cc-mpicxx.sh updated-charm-6.7.1/src/arch/mpi-linux-x86_64/cc-mpicxx.sh
+--- charm-6.7.1/src/arch/mpi-linux-x86_64/cc-mpicxx.sh	2016-11-07 20:14:26.000000000 +0530
++++ updated-charm-6.7.1/src/arch/mpi-linux-x86_64/cc-mpicxx.sh	2019-08-26 16:55:40.868903291 +0530
+@@ -14,7 +14,7 @@
+ 
+ CMK_REAL_COMPILER=`$MPICXX -show 2>/dev/null | cut -d' ' -f1 `
+ case "$CMK_REAL_COMPILER" in
+-g++)   CMK_AMD64="-m64 -fPIC" ;;
++clang++)   CMK_AMD64="-m64 -fPIC" ;;
+ icpc)  CMK_AMD64="-m64";;
+ pgCC)  CMK_AMD64="-DCMK_FIND_FIRST_OF_PREDICATE=1 --no_using_std " ;;
+ FCC)   CMK_AMD64="-Kfast -DCMK_FIND_FIRST_OF_PREDICATE=1 --variadic_macros";;
+diff -bur charm-6.7.1/src/arch/mpi-linux-x86_64/conv-mach-scyld.sh updated-charm-6.7.1/src/arch/mpi-linux-x86_64/conv-mach-scyld.sh
+--- charm-6.7.1/src/arch/mpi-linux-x86_64/conv-mach-scyld.sh	2016-11-07 20:14:26.000000000 +0530
++++ updated-charm-6.7.1/src/arch/mpi-linux-x86_64/conv-mach-scyld.sh	2019-08-26 16:55:40.868903291 +0530
+@@ -1,14 +1,14 @@
+ 
+ case "$CMK_CC" in
+ mpicc*)
+-	CMK_CPP_C="gcc -E "
+-	CMK_CC="gcc -fPIC"
+-	CMK_CC_RELIABLE="gcc  -fPIC"
+-	CMK_CC_FASTEST="gcc  -fPIC"
+-	CMK_CXX="g++ -fPIC"
+-	CMK_CXXPP="gcc -E "
+-	CMK_LD="gcc"
+-	CMK_LDXX="g++"
++	CMK_CPP_C="clang -E "
++	CMK_CC="clang -fPIC"
++	CMK_CC_RELIABLE="clang  -fPIC"
++	CMK_CC_FASTEST="clang  -fPIC"
++	CMK_CXX="clang++ -fPIC"
++	CMK_CXXPP="clang -E "
++	CMK_LD="clang"
++	CMK_LDXX="clang++"
+ 
+ # native compiler for compiling charmxi, etc
+ 	CMK_NATIVE_CC="$CMK_CC"
+Only in updated-charm-6.7.1/src/arch/mpi-linux-x86_64: conv-mach-scyld.sh.orig
+Only in updated-charm-6.7.1/src/arch/mpi-linux-x86_64: conv-mach-scyld.sh.rej
+diff -bur charm-6.7.1/src/arch/mpi-linux-x86_64/conv-mach.sh updated-charm-6.7.1/src/arch/mpi-linux-x86_64/conv-mach.sh
+--- charm-6.7.1/src/arch/mpi-linux-x86_64/conv-mach.sh	2016-11-07 20:14:26.000000000 +0530
++++ updated-charm-6.7.1/src/arch/mpi-linux-x86_64/conv-mach.sh	2019-08-26 16:55:40.868903291 +0530
+@@ -23,7 +23,7 @@
+ 
+ CMK_REAL_COMPILER=`$MPICXX -show 2>/dev/null | cut -d' ' -f1 `
+ case "$CMK_REAL_COMPILER" in
+-g++) CMK_AMD64_CC="$CMK_GCC64"; CMK_AMD64_CXX="$CMK_GCC64" ;;
++clang++) CMK_AMD64_CC="$CMK_GCC64"; CMK_AMD64_CXX="$CMK_GCC64" ;;
+ pgCC)  CMK_AMD64_CC="-fPIC"; CMK_AMD64_CXX="-fPIC -DCMK_FIND_FIRST_OF_PREDICATE=1 --no_using_std " ;;
+ charmc)  echo "Error> charmc can not call AMPI's mpicxx/mpiCC wrapper! Please fix your PATH."; exit 1 ;;
+ esac
+@@ -38,10 +38,10 @@
+ CMK_LIBS="-lckqt $CMK_SYSLIBS "
+ CMK_LD_LIBRARY_PATH="-Wl,-rpath,$CHARMLIBSO/"
+ 
+-CMK_NATIVE_CC="gcc $CMK_GCC64 "
+-CMK_NATIVE_LD="gcc $CMK_GCC64 "
+-CMK_NATIVE_CXX="g++ $CMK_GCC64 "
+-CMK_NATIVE_LDXX="g++ $CMK_GCC64 "
++CMK_NATIVE_CC="clang $CMK_GCC64 "
++CMK_NATIVE_LD="clang $CMK_GCC64 "
++CMK_NATIVE_CXX="clang++ $CMK_GCC64 "
++CMK_NATIVE_LDXX="clang++ $CMK_GCC64 "
+ CMK_NATIVE_LIBS=""
+ 
+ # fortran compiler 
+@@ -51,7 +51,7 @@
+ #    CMK_FPP="/lib/cpp -P -CC"
+ #    CMK_CF90="$CMK_CF90 -fpic -fautomatic -fdollar-ok "
+ #    CMK_CF90_FIXED="$CMK_CF90 -ffixed-form "
+-#    CMK_F90LIBS="-lgfortran "
++#    CMK_F90LIBS="  "
+ #    CMK_F90_USE_MODDIR=1
+ #    CMK_F90_MODINC="-I"
+ #    CMK_MOD_NAME_ALLCAPS=
+diff -bur charm-6.7.1/src/libs/ck-libs/ckloop/Makefile updated-charm-6.7.1/src/libs/ck-libs/ckloop/Makefile
+--- charm-6.7.1/src/libs/ck-libs/ckloop/Makefile	2016-11-07 20:14:28.000000000 +0530
++++ updated-charm-6.7.1/src/libs/ck-libs/ckloop/Makefile	2019-08-26 16:55:40.852903122 +0530
+@@ -38,7 +38,7 @@
+         for i in $(LIBOBJ) ; do \
+ 	      SRCFILE=`basename $$i .o`.C ; \
+               echo "checking dependencies for $$i : $$SRCFILE" ; \
+-              g++ -MM -Wno-deprecated -I$(CDIR)/tmp $$SRCFILE >> $(DEPENDFILE); \
++              clang++ -MM -Wno-deprecated -I$(CDIR)/tmp $$SRCFILE >> $(DEPENDFILE); \
+               echo '	$$(CHARMC) -I$(CDIR)/tmp -o '$$i $$SRCFILE >> $(DEPENDFILE) ; \
+         done; 
+ 
+Only in updated-charm-6.7.1/src/libs/ck-libs/ckloop: Makefile.orig
+Only in updated-charm-6.7.1/src/libs/ck-libs/ckloop: Makefile.rej
+diff -bur charm-6.7.1/src/libs/ck-libs/completion/Makefile updated-charm-6.7.1/src/libs/ck-libs/completion/Makefile
+--- charm-6.7.1/src/libs/ck-libs/completion/Makefile	2016-11-07 20:14:28.000000000 +0530
++++ updated-charm-6.7.1/src/libs/ck-libs/completion/Makefile	2019-08-26 16:55:40.852903122 +0530
+@@ -45,7 +45,7 @@
+         for i in $(LIBOBJ) ; do \
+ 	      SRCFILE=`basename $$i .o`.C ; \
+               echo "checking dependencies for $$i : $$SRCFILE" ; \
+-              g++ -MM -Wno-deprecated -I$(CDIR)/tmp $$SRCFILE >> $(DEPENDFILE); \
++              clang++ -MM -Wno-deprecated -I$(CDIR)/tmp $$SRCFILE >> $(DEPENDFILE); \
+               echo '	$$(CHARMC) -I$(CDIR)/tmp -o '$$i $$SRCFILE >> $(DEPENDFILE) ; \
+         done; 
+ 
+Only in updated-charm-6.7.1/src/libs/ck-libs/completion: Makefile.orig
+Only in updated-charm-6.7.1/src/libs/ck-libs/completion: Makefile.rej
+diff -bur charm-6.7.1/src/libs/ck-libs/multicast/Makefile updated-charm-6.7.1/src/libs/ck-libs/multicast/Makefile
+--- charm-6.7.1/src/libs/ck-libs/multicast/Makefile	2016-11-07 20:14:29.000000000 +0530
++++ updated-charm-6.7.1/src/libs/ck-libs/multicast/Makefile	2019-08-26 16:55:40.852903122 +0530
+@@ -53,7 +53,7 @@
+         for i in $(LIBOBJ) ; do \
+ 	      SRCFILE=`basename $$i .o`.C ; \
+               echo "checking dependencies for $$i : $$SRCFILE" ; \
+-              g++ -MM -Wno-deprecated -I$(CDIR)/tmp $$SRCFILE >> $(DEPENDFILE); \
++              clang++ -MM -Wno-deprecated -I$(CDIR)/tmp $$SRCFILE >> $(DEPENDFILE); \
+               echo '	$$(CHARMC) -I$(CDIR)/tmp -o '$$i $$SRCFILE >> $(DEPENDFILE) ; \
+         done; 
+ 
+Only in updated-charm-6.7.1/src/libs/ck-libs/multicast: Makefile.orig
+Only in updated-charm-6.7.1/src/libs/ck-libs/multicast: Makefile.rej
+diff -bur charm-6.7.1/src/libs/ck-libs/NDMeshStreamer/Makefile updated-charm-6.7.1/src/libs/ck-libs/NDMeshStreamer/Makefile
+--- charm-6.7.1/src/libs/ck-libs/NDMeshStreamer/Makefile	2016-11-07 20:14:27.000000000 +0530
++++ updated-charm-6.7.1/src/libs/ck-libs/NDMeshStreamer/Makefile	2019-08-26 16:55:40.852903122 +0530
+@@ -52,7 +52,7 @@
+         for i in $(LIBOBJ) ; do \
+ 	      SRCFILE=`basename $$i .o`.C ; \
+               echo "checking dependencies for $$i : $$SRCFILE" ; \
+-              g++ -MM -Wno-deprecated -I$(CDIR)/tmp -I../completion $$SRCFILE >> $(DEPENDFILE); \
++              clang++ -MM -Wno-deprecated -I$(CDIR)/tmp -I../completion $$SRCFILE >> $(DEPENDFILE); \
+               echo '	$$(CHARMC) -I$(CDIR)/tmp -o '$$i $$SRCFILE >> $(DEPENDFILE) ; \
+         done;
+ 
+Only in updated-charm-6.7.1/src/libs/ck-libs/NDMeshStreamer: Makefile.orig
+Only in updated-charm-6.7.1/src/libs/ck-libs/NDMeshStreamer: Makefile.rej
+diff -bur charm-6.7.1/src/QuickThreads/Makefile updated-charm-6.7.1/src/QuickThreads/Makefile
+--- charm-6.7.1/src/QuickThreads/Makefile	2016-11-07 20:14:25.000000000 +0530
++++ updated-charm-6.7.1/src/QuickThreads/Makefile	2019-08-26 16:55:40.856903165 +0530
+@@ -1,5 +1,5 @@
+ 
+-CC=gcc -I. -O2
++CC=clang -I. -O2
+ 
+ all: qt stp testpgm
+ 
+diff -bur charm-6.7.1/src/scripts/Makefile updated-charm-6.7.1/src/scripts/Makefile
+--- charm-6.7.1/src/scripts/Makefile	2016-11-07 20:14:29.000000000 +0530
++++ updated-charm-6.7.1/src/scripts/Makefile	2019-08-26 16:55:40.840902996 +0530
+@@ -942,7 +942,7 @@
+ 	      SRCFILE=`basename $$i .o`.C ; \
+ 	      [ ! -f $$SRCFILE ] && SRCFILE=`basename $$i .o`.c ;	\
+               echo "checking dependencies for $$SRCFILE" ; \
+-              if g++ -MM -Wno-deprecated -I. -I$(INC) $$SRCFILE  >> $(DEPENDFILE); then true ; else echo '' ; echo "Compilation of '$$SRCFILE' failed, please fix it first!!!!" ; exit; fi;  \
++              if clang++ -MM -Wno-deprecated -I. -I$(INC) $$SRCFILE  >> $(DEPENDFILE); then true ; else echo '' ; echo "Compilation of '$$SRCFILE' failed, please fix it first!!!!" ; exit; fi;  \
+ 	      echo '' >> $(DEPENDFILE) ; \
+         done;  \
+ 
+@@ -968,7 +968,7 @@
+ 	      found=`/usr/bin/find $$SRCDIR -depth 1 -name $$SRCFILE`; \
+               [ ! $$found ] && SRCFILE=`basename $$i .o`.c ; \
+               echo "checking dependencies for $$SRCFILE" ; \
+-              if g++ -MM -Wno-deprecated -I. -I$(INC) $$SRCFILE  >> $(DEPENDFILE); then true ; else echo '' ; echo "Compilation of '$$SRCFILE' failed, please fix it first!!!!" ; exit; fi;  \
++              if clang++ -MM -Wno-deprecated -I. -I$(INC) $$SRCFILE  >> $(DEPENDFILE); then true ; else echo '' ; echo "Compilation of '$$SRCFILE' failed, please fix it first!!!!" ; exit; fi;  \
+ 	      echo '' >> $(DEPENDFILE) ; \
+         done;  \
+ 
+diff -bur charm-6.7.1/tests/charm++/megatest/Makefile updated-charm-6.7.1/tests/charm++/megatest/Makefile
+--- charm-6.7.1/tests/charm++/megatest/Makefile	2016-11-07 20:14:30.000000000 +0530
++++ updated-charm-6.7.1/tests/charm++/megatest/Makefile	2019-08-26 16:55:40.820902785 +0530
+@@ -118,7 +118,7 @@
+         for i in $(OBJS) ; do \
+               SRCFILE=`basename $$i .o`.C ; \
+               echo "checking dependencies for $$SRCFILE" ; \
+-              g++ -MM -I$(CHARMINC) $$SRCFILE | \
++              clang++ -MM -I$(CHARMINC) $$SRCFILE | \
+               perl $(CHARMBIN)/dep.pl $(CHARMINC) /usr/include /usr/local >> $(DEPENDFILE); \
+               echo '	$$(CHARMC) -o '$$i $$SRCFILE >> $(DEPENDFILE) ; \
+         done;
+--- charm-6.7.1/src/scripts/configure	2016-11-07 20:14:31.000000000 +0530
++++ updated-charm/charm-6.7.1/src/scripts/configure	2020-10-21 12:54:06.476958828 +0530
+@@ -2141,8 +2141,8 @@
+ $as_echo_n "checking \"$1\"... " >&6; }
+ 	echo "### $1" >> $charmout
+ 	cat $t >> $charmout
+-	echo $CMK_CXX -I../include -I. $CMK_LIBDIR $CMK_INCDIR $CMK_SYSINC $OPTS_CXX $OPTS_LD -c $t -o test.o $4 >> $charmout
+-	$CMK_CXX -I../include -I. $CMK_LIBDIR $CMK_INCDIR $CMK_SYSINC $OPTS_CXX $OPTS_LD -c $t -o test.o $4 > out 2>&1
++	echo $CMK_CXX -I../include -I. $CMK_LIBDIR $CMK_INCDIR $CMK_SYSINC $OPTS_CXX $OPTS_LD -Qunused-arguments -c $t -o test.o $4 >> $charmout
++	$CMK_CXX -I../include -I. $CMK_LIBDIR $CMK_INCDIR $CMK_SYSINC $OPTS_CXX $OPTS_LD -Qunused-arguments  -c $t -o test.o $4 > out 2>&1
+ 	test_result $? "$1" "$2" "$3"
+  	strictpass=$pass
+ 	strictfail=$fail

--- a/recipes/namd/3.0/gh200/repo/packages/charmpp/charm_6.8.2_aocc.patch
+++ b/recipes/namd/3.0/gh200/repo/packages/charmpp/charm_6.8.2_aocc.patch
@@ -1,0 +1,165 @@
+diff -ruN 00/NAMD_2.13_Source/charm-6.8.2/src/arch/mpi-linux-x86_64/cc-mpicxx.sh 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/src/arch/mpi-linux-x86_64/cc-mpicxx.sh
+--- 00/NAMD_2.13_Source/charm-6.8.2/src/arch/mpi-linux-x86_64/cc-mpicxx.sh	2018-01-11 19:06:19.000000000 -0600
++++ 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/src/arch/mpi-linux-x86_64/cc-mpicxx.sh	2019-11-12 06:02:23.005454343 -0600
+@@ -15,6 +15,7 @@
+ CMK_REAL_COMPILER=`$MPICXX -show 2>/dev/null | cut -d' ' -f1 `
+ case "$CMK_REAL_COMPILER" in
+ g++)   CMK_AMD64="-m64 -fPIC" ;;
++clang++)   CMK_AMD64="-m64 -fPIC" ;;
+ icpc)  CMK_AMD64="-m64";;
+ pgCC)  CMK_AMD64="-DCMK_FIND_FIRST_OF_PREDICATE=1 --no_using_std " ;;
+ FCC)   CMK_AMD64="-Kfast -DCMK_FIND_FIRST_OF_PREDICATE=1 --variadic_macros";;
+diff -ruN 00/NAMD_2.13_Source/charm-6.8.2/src/arch/mpi-linux-x86_64/conv-mach-scyld.sh 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/src/arch/mpi-linux-x86_64/conv-mach-scyld.sh
+--- 00/NAMD_2.13_Source/charm-6.8.2/src/arch/mpi-linux-x86_64/conv-mach-scyld.sh	2018-01-11 19:06:19.000000000 -0600
++++ 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/src/arch/mpi-linux-x86_64/conv-mach-scyld.sh	2019-11-12 06:05:22.666969636 -0600
+@@ -1,13 +1,14 @@
+ 
+ case "$CMK_CC" in
+ mpicc*)
+-	CMK_CPP_C="gcc -E "
+-	CMK_CC="gcc -fPIC"
+-	CMK_CC_RELIABLE="gcc  -fPIC"
+-	CMK_CC_FASTEST="gcc  -fPIC"
+-	CMK_CXX="g++ -fPIC"
+-	CMK_LD="gcc"
+-	CMK_LDXX="g++"
++	CMK_CPP_C="clang -E "
++	CMK_CC="clang -fPIC"
++	CMK_CC_RELIABLE="clang  -fPIC"
++	CMK_CC_FASTEST="clang  -fPIC"
++	CMK_CXXPP="clang -E "
++	CMK_CXX="clang++ -fPIC"
++	CMK_LD="clang"
++	CMK_LDXX="clang++"
+ 
+ # native compiler for compiling charmxi, etc
+ 	CMK_NATIVE_CC="$CMK_CC"
+diff -ruN 00/NAMD_2.13_Source/charm-6.8.2/src/arch/mpi-linux-x86_64/conv-mach.sh 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/src/arch/mpi-linux-x86_64/conv-mach.sh
+--- 00/NAMD_2.13_Source/charm-6.8.2/src/arch/mpi-linux-x86_64/conv-mach.sh	2018-01-11 19:06:19.000000000 -0600
++++ 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/src/arch/mpi-linux-x86_64/conv-mach.sh	2019-11-12 06:07:41.361999246 -0600
+@@ -23,6 +23,7 @@
+ 
+ CMK_REAL_COMPILER=`$MPICXX -show 2>/dev/null | cut -d' ' -f1 `
+ case "$CMK_REAL_COMPILER" in
++clang++) CMK_AMD64_CC="$CMK_GCC64"; CMK_AMD64_CXX="$CMK_GCC64" ;;
+ g++) CMK_AMD64_CC="$CMK_GCC64"; CMK_AMD64_CXX="$CMK_GCC64" ;;
+ pgCC)  CMK_AMD64_CC='-fPIC'; CMK_AMD64_CXX='-fPIC -DCMK_FIND_FIRST_OF_PREDICATE=1 --no_using_std ' ;;
+ charmc)  echo "Error> charmc can not call AMPI's mpicxx/mpiCC wrapper! Please fix your PATH."; exit 1 ;;
+@@ -37,10 +38,10 @@
+ CMK_LIBS="-lckqt $CMK_SYSLIBS "
+ CMK_LD_LIBRARY_PATH="-Wl,-rpath,$CHARMLIBSO/"
+ 
+-CMK_NATIVE_CC="gcc $CMK_GCC64 "
+-CMK_NATIVE_LD="gcc $CMK_GCC64 "
+-CMK_NATIVE_CXX="g++ $CMK_GCC64 "
+-CMK_NATIVE_LDXX="g++ $CMK_GCC64 "
++CMK_NATIVE_CC="clang $CMK_GCC64 "
++CMK_NATIVE_LD="clang $CMK_GCC64 "
++CMK_NATIVE_CXX="clang++ $CMK_GCC64 "
++CMK_NATIVE_LDXX="clang++ $CMK_GCC64 "
+ CMK_NATIVE_LIBS=''
+ 
+ # fortran compiler
+diff -ruN 00/NAMD_2.13_Source/charm-6.8.2/src/libs/ck-libs/ckloop/Makefile 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/src/libs/ck-libs/ckloop/Makefile
+--- 00/NAMD_2.13_Source/charm-6.8.2/src/libs/ck-libs/ckloop/Makefile	2018-01-11 19:06:15.000000000 -0600
++++ 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/src/libs/ck-libs/ckloop/Makefile	2019-11-12 06:09:16.200438412 -0600
+@@ -38,7 +38,7 @@
+         for i in $(LIBOBJ) ; do \
+ 	      SRCFILE=`basename $$i .o`.C ; \
+               echo "checking dependencies for $$i : $$SRCFILE" ; \
+-              g++ -MM -Wno-deprecated -I$(CDIR)/tmp $$SRCFILE >> $(DEPENDFILE); \
++              clang++ -MM -Wno-deprecated -I$(CDIR)/tmp $$SRCFILE >> $(DEPENDFILE); \
+               echo '	$$(CHARMC) -I$(CDIR)/tmp -o '$$i $$SRCFILE >> $(DEPENDFILE) ; \
+         done; 
+ 
+diff -ruN 00/NAMD_2.13_Source/charm-6.8.2/src/libs/ck-libs/completion/Makefile 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/src/libs/ck-libs/completion/Makefile
+--- 00/NAMD_2.13_Source/charm-6.8.2/src/libs/ck-libs/completion/Makefile	2018-01-11 19:06:16.000000000 -0600
++++ 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/src/libs/ck-libs/completion/Makefile	2019-11-12 06:09:41.247346697 -0600
+@@ -45,7 +45,7 @@
+         for i in $(LIBOBJ) ; do \
+ 	      SRCFILE=`basename $$i .o`.C ; \
+               echo "checking dependencies for $$i : $$SRCFILE" ; \
+-              g++ -MM -Wno-deprecated -I$(CDIR)/tmp $$SRCFILE >> $(DEPENDFILE); \
++              clang++ -MM -Wno-deprecated -I$(CDIR)/tmp $$SRCFILE >> $(DEPENDFILE); \
+               echo '	$$(CHARMC) -I$(CDIR)/tmp -o '$$i $$SRCFILE >> $(DEPENDFILE) ; \
+         done; 
+ 
+diff -ruN 00/NAMD_2.13_Source/charm-6.8.2/src/libs/ck-libs/NDMeshStreamer/Makefile 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/src/libs/ck-libs/NDMeshStreamer/Makefile
+--- 00/NAMD_2.13_Source/charm-6.8.2/src/libs/ck-libs/NDMeshStreamer/Makefile	2018-01-11 19:06:15.000000000 -0600
++++ 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/src/libs/ck-libs/NDMeshStreamer/Makefile	2019-11-12 06:09:59.079993368 -0600
+@@ -52,7 +52,7 @@
+         for i in $(LIBOBJ) ; do \
+ 	      SRCFILE=`basename $$i .o`.C ; \
+               echo "checking dependencies for $$i : $$SRCFILE" ; \
+-              g++ -MM -Wno-deprecated -I$(CDIR)/tmp -I../completion $$SRCFILE >> $(DEPENDFILE); \
++              clang++ -MM -Wno-deprecated -I$(CDIR)/tmp -I../completion $$SRCFILE >> $(DEPENDFILE); \
+               echo '	$$(CHARMC) -I$(CDIR)/tmp -o '$$i $$SRCFILE >> $(DEPENDFILE) ; \
+         done;
+ 
+diff -ruN 00/NAMD_2.13_Source/charm-6.8.2/src/QuickThreads/Makefile 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/src/QuickThreads/Makefile
+--- 00/NAMD_2.13_Source/charm-6.8.2/src/QuickThreads/Makefile	2018-01-11 19:06:13.000000000 -0600
++++ 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/src/QuickThreads/Makefile	2019-11-12 06:10:37.744395459 -0600
+@@ -1,5 +1,5 @@
+ 
+-CC=gcc -I. -O2
++CC=clang -I. -O2
+ 
+ all: qt stp testpgm
+ 
+diff -ruN 00/NAMD_2.13_Source/charm-6.8.2/src/scripts/Makefile 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/src/scripts/Makefile
+--- 00/NAMD_2.13_Source/charm-6.8.2/src/scripts/Makefile	2018-01-11 19:06:20.000000000 -0600
++++ 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/src/scripts/Makefile	2019-11-12 06:10:59.888198461 -0600
+@@ -962,7 +962,7 @@
+ 	      SRCFILE=`basename $$i .o`.C ; \
+ 	      [ ! -f $$SRCFILE ] && SRCFILE=`basename $$i .o`.c ;	\
+               echo "checking dependencies for $$SRCFILE" ; \
+-              if g++ -std=c++0x -MM -Wno-deprecated -I. -I$(INC) $$SRCFILE  >> $(DEPENDFILE); then true ; else echo '' ; echo "Compilation of '$$SRCFILE' failed, please fix it first!!!!" ; exit; fi;  \
++              if clang++ -std=c++0x -MM -Wno-deprecated -I. -I$(INC) $$SRCFILE  >> $(DEPENDFILE); then true ; else echo '' ; echo "Compilation of '$$SRCFILE' failed, please fix it first!!!!" ; exit; fi;  \
+ 	      echo '' >> $(DEPENDFILE) ; \
+         done;  \
+ 
+@@ -988,7 +988,7 @@
+ 	      found=`/usr/bin/find $$SRCDIR -depth 1 -name $$SRCFILE`; \
+               [ ! $$found ] && SRCFILE=`basename $$i .o`.c ; \
+               echo "checking dependencies for $$SRCFILE" ; \
+-              if g++ -std=c++0x -MM -Wno-deprecated -I. -I$(INC) $$SRCFILE  >> $(DEPENDFILE); then true ; else echo '' ; echo "Compilation of '$$SRCFILE' failed, please fix it first!!!!" ; exit; fi;  \
++              if clang++ -std=c++0x -MM -Wno-deprecated -I. -I$(INC) $$SRCFILE  >> $(DEPENDFILE); then true ; else echo '' ; echo "Compilation of '$$SRCFILE' failed, please fix it first!!!!" ; exit; fi;  \
+ 	      echo '' >> $(DEPENDFILE) ; \
+         done;  \
+ 
+diff -ruN 00/NAMD_2.13_Source/charm-6.8.2/tests/charm++/megatest/Makefile 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/tests/charm++/megatest/Makefile
+--- 00/NAMD_2.13_Source/charm-6.8.2/tests/charm++/megatest/Makefile	2018-01-11 19:06:18.000000000 -0600
++++ 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/tests/charm++/megatest/Makefile	2019-11-12 06:11:38.193587531 -0600
+@@ -116,7 +116,7 @@
+         for i in $(OBJS) ; do \
+               SRCFILE=`basename $$i .o`.C ; \
+               echo "checking dependencies for $$SRCFILE" ; \
+-              g++ -std=c++0x -MM -I$(CHARMINC) $$SRCFILE | \
++              clang++ -std=c++0x -MM -I$(CHARMINC) $$SRCFILE | \
+               perl $(CHARMBIN)/dep.pl $(CHARMINC) /usr/include /usr/local >> $(DEPENDFILE); \
+               echo '	$$(CHARMC) -o '$$i $$SRCFILE >> $(DEPENDFILE) ; \
+         done;
+--- 00/NAMD_2.13_Source/charm-6.8.2/src/scripts/configure	2018-01-12 06:36:21.000000000 +0530
++++ 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/src/scripts/configure	2020-10-21 15:01:20.240748316 +0530
+@@ -2183,8 +2183,8 @@
+ $as_echo_n "checking \"$1\"... " >&6; }
+ 	echo "### $1" >> $charmout
+ 	cat $tc >> $charmout
+-	echo $CMK_CC -I../include -I. $CMK_LIBDIR $CMK_INCDIR $CMK_SYSINC $OPTS_CC $OPTS_LD -c $tc -o test.o $4 >> $charmout
+-	$CMK_CC -I../include -I. $CMK_LIBDIR $CMK_INCDIR $CMK_SYSINC $OPTS_CC $OPTS_LD -c $tc -o test.o $4 > out 2>&1
++	echo $CMK_CC -I../include -I. $CMK_LIBDIR $CMK_INCDIR $CMK_SYSINC $OPTS_CC $OPTS_LD -Qunused-arguments -c $tc -o test.o $4 >> $charmout
++	$CMK_CC -I../include -I. $CMK_LIBDIR $CMK_INCDIR $CMK_SYSINC $OPTS_CC $OPTS_LD -Qunused-arguments  -c $tc -o test.o $4 > out 2>&1
+ 	test_result $? "$1" "$2" "$3"
+  	strictpass=$pass
+ 	strictfail=$fail
+@@ -2208,8 +2208,8 @@
+ $as_echo_n "checking \"$1\"... " >&6; }
+ 	echo "### $1" >> $charmout
+ 	cat $t >> $charmout
+-	echo $CMK_CXX -I../include -I. $CMK_LIBDIR $CMK_INCDIR $CMK_SYSINC $OPTS_CXX $OPTS_LD -c $t -o test.o $4 >> $charmout
+-	$CMK_CXX -I../include -I. $CMK_LIBDIR $CMK_INCDIR $CMK_SYSINC $OPTS_CXX $OPTS_LD -c $t -o test.o $4 > out 2>&1
++	echo $CMK_CXX -I../include -I. $CMK_LIBDIR $CMK_INCDIR $CMK_SYSINC $OPTS_CXX $OPTS_LD -Qunused-arguments -c $t -o test.o $4 >> $charmout
++	$CMK_CXX -I../include -I. $CMK_LIBDIR $CMK_INCDIR $CMK_SYSINC $OPTS_CXX $OPTS_LD -Qunused-arguments -c $t -o test.o $4 > out 2>&1
+ 	test_result $? "$1" "$2" "$3"
+  	strictpass=$pass
+ 	strictfail=$fail

--- a/recipes/namd/3.0/gh200/repo/packages/charmpp/fj.patch
+++ b/recipes/namd/3.0/gh200/repo/packages/charmpp/fj.patch
@@ -1,0 +1,61 @@
+diff --git a/src/arch/netlrts-linux-arm8/cc-fcc.h b/src/arch/netlrts-linux-arm8/cc-fcc.h
+new file mode 100644
+index 000000000..f25b2250a
+--- /dev/null
++++ b/src/arch/netlrts-linux-arm8/cc-fcc.h
+@@ -0,0 +1,6 @@
++#undef CMK_DLL_CC
++
++#undef  CMK_COMPILEMODE_ORIG
++#undef  CMK_COMPILEMODE_ANSI
++#define CMK_COMPILEMODE_ORIG                               1
++#define CMK_COMPILEMODE_ANSI                               0
+diff --git a/src/arch/netlrts-linux-arm8/cc-fcc.sh b/src/arch/netlrts-linux-arm8/cc-fcc.sh
+new file mode 100644
+index 000000000..0efdc417e
+--- /dev/null
++++ b/src/arch/netlrts-linux-arm8/cc-fcc.sh
+@@ -0,0 +1,15 @@
++# Assumes Fujitsu C/C++ compiler:
++CMK_CPP_CHARM="cpp -P"
++CMK_CPP_C="fcc$CMK_COMPILER_SUFFIX"
++CMK_CC="fcc$CMK_COMPILER_SUFFIX"
++CMK_LD="fcc$CMK_COMPILER_SUFFIX"
++CMK_CXX="FCC$CMK_COMPILER_SUFFIX"
++CMK_LDXX="FCC$CMK_COMPILER_SUFFIX"
++
++CMK_CPP_C_FLAGS="-E"
++
++CMK_PIC='' # empty string: will be reset to default by conv-config.sh
++CMK_PIE='-fPIE'
++
++CMK_COMPILER='fcc'
++CMK_WARNINGS_ARE_ERRORS="-Werror"
+diff --git a/src/arch/netlrts-linux-arm8/conv-mach-frt.h b/src/arch/netlrts-linux-arm8/conv-mach-frt.h
+new file mode 100644
+index 000000000..d1ab56ad5
+--- /dev/null
++++ b/src/arch/netlrts-linux-arm8/conv-mach-frt.h
+@@ -0,0 +1 @@
++/* This file intentionally left blank */
+diff --git a/src/arch/netlrts-linux-arm8/conv-mach-frt.sh b/src/arch/netlrts-linux-arm8/conv-mach-frt.sh
+new file mode 100644
+index 000000000..1de93a5ed
+--- /dev/null
++++ b/src/arch/netlrts-linux-arm8/conv-mach-frt.sh
+@@ -0,0 +1,15 @@
++CMK_CF90="frt"
++
++CMK_FPP="$CMK_CF90 -Ccpp"
++
++CMK_CF90_FIXED="$CMK_CF90 -Fixed "
++
++CMK_F90LIBS="-lfj90i -lfj90f -lfjsrcinfo -lfjsrcinfo -lelf"
++
++CMK_CF77=$CMK_CF90
++CMK_F77LIBS=$CMK_F90LIBS
++
++CMK_MOD_NAME_ALLCAPS=
++CMK_MOD_EXT="mod"
++CMK_F90_USE_MODDIR=1
++CMK_F90_MODINC="-I"

--- a/recipes/namd/3.0/gh200/repo/packages/charmpp/mpi.patch
+++ b/recipes/namd/3.0/gh200/repo/packages/charmpp/mpi.patch
@@ -1,0 +1,19 @@
+--- old/src/scripts/configure
++++ new/src/scripts/configure
+@@ -3293,10 +3293,16 @@
+         test_link "whether -lmpi" "ok" "no" "-lmpi"
+         if test $pass -eq 1
+         then
+                 add_flag CMK_SYSLIBS='"$CMK_SYSLIBS -lmpi"' "mpi lib"
+         else
++          test_link "whether -lmpi -lmpi_cxx" "ok" "no" "-lmpi -lmpi_cxx"
++          if test $pass -eq 1
++          then
++            add_flag CMK_SYSLIBS='"$CMK_SYSLIBS -lmpi -lmpi_cxx"' "mpi lib"
++          else
+                 echo "Error: can not find mpi library"
+                 test_finish 1
++          fi
+         fi
+       fi
+     else

--- a/recipes/namd/3.0/gh200/repo/packages/charmpp/nvhpc.patch
+++ b/recipes/namd/3.0/gh200/repo/packages/charmpp/nvhpc.patch
@@ -1,0 +1,77 @@
+--- /dev/null	2020-08-25 10:23:08.110000124 -0700
++++ b/src/arch/common/cc-nvc.h	2020-09-03 08:11:13.912665728 -0700
+@@ -0,0 +1,9 @@
++#undef CMK_DLL_CC
++
++/* pgcc can not compile RDTSC timer */
++#if CMK_TIMER_USE_RDTSC
++# undef CMK_TIMER_USE_GETRUSAGE
++# undef CMK_TIMER_USE_RDTSC
++# define CMK_TIMER_USE_GETRUSAGE                            1
++# define CMK_TIMER_USE_RDTSC                                0
++#endif
+--- /dev/null	2020-08-25 10:23:08.110000124 -0700
++++ b/src/arch/common/cc-nvc.sh	2020-09-03 08:11:01.439597250 -0700
+@@ -0,0 +1,42 @@
++
++# machine specific recommendation
++CMK_DEFS=""
++case `hostname` in
++*.ranger.tacc.utexas.edu) CMK_DEFS="-tp barcelona-64 " ;;
++esac
++
++CMK_CPP_C="nvc -E "
++CMK_CC="nvc -fPIC -DCMK_FIND_FIRST_OF_PREDICATE=1 "
++CMK_CC_RELIABLE="gcc "
++CMK_CXX="nvc++ -fPIC -DCMK_FIND_FIRST_OF_PREDICATE=1 --no_using_std "
++CMK_LD="$CMK_CC "
++CMK_LDXX="$CMK_CXX "
++CMK_PIE=" "
++
++# compiler for compiling sequential programs
++# nvc can not handle QT right for generic64, so always use gcc
++CMK_SEQ_CC="gcc -fPIC "
++CMK_SEQ_LD="$CMK_SEQ_CC "
++CMK_SEQ_CXX="nvc++ -fPIC --no_using_std "
++CMK_SEQ_LDXX="$CMK_SEQ_CXX"
++CMK_SEQ_LIBS=""
++
++# compiler for native programs
++CMK_NATIVE_CC="gcc "
++CMK_NATIVE_LD="gcc "
++CMK_NATIVE_CXX="g++ "
++CMK_NATIVE_LDXX="g++ "
++CMK_NATIVE_LIBS=""
++
++# fortran compiler
++CMK_CF77="nvfortran "
++CMK_CF90="nvfortran "
++CMK_CF90_FIXED="$CMK_CF90 -Mfixed "
++f90libdir="."
++f90bindir=`which nvfortran 2>/dev/null`
++if test -n "$f90bindir"
++then
++  f90libdir="$f90bindir/../lib"
++fi
++CMK_F90LIBS="-L$f90libdir "
++CMK_F90_USE_MODDIR=""
+--- /dev/null	2020-08-25 10:23:08.110000124 -0700
++++ b/src/arch/common/conv-mach-nvfortran.sh	2020-09-03 08:25:09.042243776 -0700
+@@ -0,0 +1,13 @@
++COMMENT="Use nvfortran fortran compiler"
++NVFORTRAN=`which nvfortran`
++if test x$NVFORTRAN = x
++then
++  echo charmc> Fatal error: nvfortran not found!
++  exit 1
++fi
++CMK_CF77="$NVFORTRAN "
++CMK_CF90="$NVFORTRAN "
++CMK_CF90_FIXED="$CMK_CF90 -Mfixed "
++CMK_F90LIBS="-lm "
++CMK_F90_MODINC="-module "
++CMK_F90_USE_MODDIR=""
+--- /dev/null   2020-08-25 10:23:08.110000124 -0700
++++ b/src/arch/common/conv-mach-nvfortran.h	2020-09-03 08:25:09.042243776 -0700
+@@ -0,0 +1,1 @@
++/* empty file */

--- a/recipes/namd/3.0/gh200/repo/packages/charmpp/ofi-crayshasta-arm-7.0.0.patch
+++ b/recipes/namd/3.0/gh200/repo/packages/charmpp/ofi-crayshasta-arm-7.0.0.patch
@@ -1,0 +1,11 @@
+--- a/src/arch/ofi-crayshasta/conv-mach.h
++++ b/src/arch/ofi-crayshasta/conv-mach.h
+@@ -74,7 +74,7 @@
+ #define CMK_LBDB_ON					   1
+ 
+ #define CMK_64BIT                      1
+-#define CMK_AMD64                      1
++#define CMK_ARM                        1
+ 
+ /* Other possible definitions:
+ 

--- a/recipes/namd/3.0/gh200/repo/packages/charmpp/ofi-crayshasta-arm-8.0.0.patch
+++ b/recipes/namd/3.0/gh200/repo/packages/charmpp/ofi-crayshasta-arm-8.0.0.patch
@@ -1,0 +1,49 @@
+diff --git a/cmake/detect-features-c.cmake b/cmake/detect-features-c.cmake
+index 313c407c1..3f867b067 100644
+--- a/cmake/detect-features-c.cmake
++++ b/cmake/detect-features-c.cmake
+@@ -370,12 +370,7 @@ int main() {
+ if(${NETWORK} STREQUAL "ofi" OR ${NETWORK} STREQUAL "ofi-crayshasta" OR ${NETWORK} STREQUAL "ofi-linux")
+ # assume HPC installation
+ include(CMakePrintHelpers)
+-  find_package(EnvModules REQUIRED)
+   find_package(PkgConfig REQUIRED)
+-  if(EnvModules_FOUND)
+-  #at least get libfabric loaded if it isn't already
+-	env_module(load libfabric)
+-  endif()
+   set(tmp ${CMAKE_REQUIRED_LIBRARIES})
+   if(${PkgConfig_FOUND})
+ # this is tortured because pkg-config and cmake are infuriating
+diff --git a/cmake/detect-features-cxx.cmake b/cmake/detect-features-cxx.cmake
+index 64d4067cb..bd627f14d 100644
+--- a/cmake/detect-features-cxx.cmake
++++ b/cmake/detect-features-cxx.cmake
+@@ -168,14 +168,7 @@ set(CMAKE_REQUIRED_FLAGS "")
+ if(${NETWORK} STREQUAL "ofi" OR ${NETWORK} STREQUAL "ofi-crayshasta" OR ${NETWORK} STREQUAL "ofi-linux")
+ # assume HPC installation with LMOD
+   include(CMakePrintHelpers)
+-  find_package(EnvModules REQUIRED)
+   find_package(PkgConfig REQUIRED)
+-  if(EnvModules_FOUND)
+-  # we need libfabric cray-libpals and cray-pmi
+-	env_module(load libfabric)
+-	env_module(load cray-libpals)
+-	env_module(load cray-pmi)
+-  endif()
+   set(tmp ${CMAKE_REQUIRED_LIBRARIES})
+   if(${PkgConfig_FOUND})
+ # this is tortured because pkg-config and cmake are infuriating
+diff --git a/src/arch/ofi-crayshasta/conv-mach.h b/src/arch/ofi-crayshasta/conv-mach.h
+index bef80a949..b66673fe1 100644
+--- a/src/arch/ofi-crayshasta/conv-mach.h
++++ b/src/arch/ofi-crayshasta/conv-mach.h
+@@ -74,7 +74,7 @@
+ #define CMK_LBDB_ON					   1
+ 
+ #define CMK_64BIT                      1
+-#define CMK_AMD64                      1
++#define CMK_ARM                        1
+ #ifdef CMK_HAS_GET_MYADDRESS
+ #undef CMK_HAS_GET_MYADDRESS
+ #define CMK_HAS_GET_MYADDRESS 0

--- a/recipes/namd/3.0/gh200/repo/packages/charmpp/package.py
+++ b/recipes/namd/3.0/gh200/repo/packages/charmpp/package.py
@@ -1,0 +1,434 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+import os
+import platform
+import shutil
+import sys
+
+from spack.package import *
+
+
+class Charmpp(Package):
+    """Charm++ is a parallel programming framework in C++ supported by
+    an adaptive runtime system, which enhances user productivity and
+    allows programs to run portably from small multicore computers
+    (your laptop) to the largest supercomputers."""
+
+    homepage = "https://charmplusplus.org"
+    url = "https://charm.cs.illinois.edu/distrib/charm-6.8.2.tar.gz"
+    git = "https://github.com/UIUC-PPL/charm.git"
+
+    maintainers("matthiasdiener")
+
+    version("main", branch="main")
+
+    version(
+            "8.0.0",
+            sha256="e30fc1e921e5cbf3406e792d5b0ca5f211c5d8ffbfc56e56d5501d8118abcaf6",
+            url="https://github.com/charmplusplus/charm/archive/refs/tags/v8.0.0.tar.gz"
+    )
+    version("7.0.0", sha256="9c247b421bb157bdf9bc0ced3e25738c7a1dc1f7ec57b7943a7faf97f7e4fb2e")
+    version("6.10.2", sha256="7abb4cace8aebdfbb8006eac03eb766897c009cfb919da0d0a33f74c3b4e6deb")
+    version("6.10.1", sha256="ab96198105daabbb8c8bdf370f87b0523521ce502c656cb6cd5b89f69a2c70a8")
+    version("6.10.0", sha256="7c526a78aa0c202b7f0418b345138e7dc40496f0bb7b9e301e0381980450b25c")
+    version("6.9.0", sha256="85ed660e46eeb7a6fc6b32deab08226f647c244241948f6b592ebcd2b6050cbd")
+    version("6.8.2", sha256="08e6001b0e9cd00ebde179f76098767149bf7e454f29028fb9a8bfb55778698e")
+    version("6.8.1", sha256="bf39666bb9f8bad1cd17dafa3cdf35c7ef64dfaeda835cf66ae530b7baab7583")
+    version("6.8.0", sha256="deca68622932ea0c677aa764d6d24cd169a2fd99c06e7d7b6947c0f18ec2f8f3")
+    version("6.7.1", sha256="744a093874fbac03b6ae8be3ce434eff46b2ee778561e860802ed578e0810fdf")
+    version("6.7.0", sha256="6b0d8215a180c90cf6ee33ff39f66726934df34aaeeed59650dd3a0cc54d0c87")
+    version("6.6.1", sha256="2aa16fd3015dce0a0932ab5253578a72ddbcb889bc0d23584c42b28446915467")
+    version("6.6.0", sha256="c916010f2d4cc2c6bd30ea19764839d0298fb56d1696d8ff08d9fa9a61dfb1c9")
+    version("6.5.1", sha256="68aa43e2a6e476e116a7e80e385c25c6ac6497807348025505ba8bfa256ed34a")
+
+    # Support OpenMPI; see
+    # <https://github.com/UIUC-PPL/charm/issues/1206>
+    # Patch is no longer needed in versions 6.8.0+
+    patch("mpi.patch", when="@:6.7.1")
+
+    # Patch for AOCC
+    patch("charm_6.7.1_aocc.patch", when="@6.7.1 %aocc", level=1)
+    patch("charm_6.8.2_aocc.patch", when="@6.8.2 %aocc", level=3)
+
+    # support Fujitsu compiler
+    patch("fj.patch", when="%fj")
+
+    # support NVIDIA compilers
+    patch("nvhpc.patch", when="%nvhpc")
+
+    # Ignore compiler warnings while configuring
+    patch("strictpass.patch", when="@:6.8.2")
+
+    # Support Cray Shasta with ARM
+    patch("ofi-crayshasta-arm-7.0.0.patch", when="backend=ofi pmi=cray-pmi target=aarch64: @=7.0.0")
+    patch("ofi-crayshasta-arm-8.0.0.patch", when="backend=ofi pmi=cray-pmi target=aarch64: @=8.0.0")
+
+    # Build targets
+    # "target" is reserved, so we have to use something else.
+    variant(
+        "build-target",
+        default="LIBS",
+        # AMPI also builds charm++, LIBS also builds AMPI and charm++
+        values=("charm++", "AMPI", "LIBS", "ChaNGa"),
+        description="Specify the target to build",
+    )
+
+    # Communication mechanisms (choose exactly one)
+    # - Default to 'multicore' on macOS because that's probably the right choice
+    #   for a personal machine.
+    if sys.platform == "darwin":
+        backend_default = "multicore"
+    else:
+        backend_default = "netlrts"
+    variant(
+        "backend",
+        default=backend_default,
+        values=("mpi", "multicore", "netlrts", "verbs", "gni", "ucx", "ofi", "pami", "pamilrts"),
+        description="Set the backend to use",
+    )
+
+    # Process management interface
+    variant(
+        "pmi",
+        default="none",
+        values=("none", "simplepmi", "slurmpmi", "slurmpmi2", "pmix", "cray-pmi"),
+        description="The ucx/ofi/gni backends need PMI to run!",
+    )
+
+    # Other options
+    variant("papi", default=False, description="Enable PAPI integration")
+    variant("syncft", default=False, description="Compile with Charm++ fault tolerance support")
+    variant("smp", default=True, description="Enable SMP parallelism")
+    variant("tcp", default=False, description="Use TCP as transport mechanism (requires +net)")
+    variant("omp", default=False, description="Support for the integrated LLVM OpenMP runtime")
+    variant("pthreads", default=False, description="Compile with pthreads Converse threads")
+    variant("cuda", default=False, description="Enable CUDA toolkit")
+
+    variant("shared", default=True, description="Enable shared link support")
+    variant("production", default=True, description="Build charm++ with all optimizations")
+    variant("tracing", default=False, description="Enable tracing modules")
+
+    # Versions 7.0.0+ use CMake by default when it's available. It's more
+    # robust.
+    depends_on("cmake@3.4:", when="@7.0.0:", type="build")
+
+    depends_on("mpi", when="backend=mpi")
+    depends_on("papi", when="+papi")
+    depends_on("cuda", when="+cuda")
+
+    depends_on("ucx", when="backend=ucx")
+    depends_on("libfabric", when="backend=ofi")
+    depends_on("slurm@:17-11-9-2", when="pmi=slurmpmi")
+    depends_on("slurm@17-11-9-2:", when="pmi=slurmpmi2")
+
+    # FIXME : As of now spack's OpenMPI recipe does not have a PMIx variant
+    # But if users have external installs of OpenMPI with PMIx support, this
+    # will allow them to build charm++ with it.
+    depends_on("openmpi", when="pmi=pmix")
+
+    depends_on("mpi", when="pmi=simplepmi")
+    depends_on("mpi", when="pmi=slurmpmi")
+    depends_on("mpi", when="pmi=slurmpmi2")
+    depends_on("cray-mpich", when="pmi=cray-pmi")
+
+    # Git versions of Charm++ require automake and autoconf
+    depends_on("automake", when="@develop")
+    depends_on("autoconf", when="@develop")
+
+    conflicts("~tracing", "+papi")
+
+    conflicts("backend=multicore", when="~smp", msg="The 'multicore' backend always uses SMP")
+    conflicts("backend=ucx", when="@:6.9")
+
+    # Shared-lib builds with GCC are broken on macOS:
+    # https://github.com/UIUC-PPL/charm/issues/3181
+    conflicts("+shared", when="platform=darwin %gcc")
+
+    # Charm++ versions below 7.0.0 have build issues on macOS, mainly due to the
+    # pre-7.0.0 `VERSION` file conflicting with other version files on the
+    # system: https://github.com/UIUC-PPL/charm/issues/2844. Specifically, it
+    # conflicts with LLVM's `<version>` header that was added in llvm@7.0.0 to
+    # comply with the C++20 standard:
+    # https://en.cppreference.com/w/cpp/header/version. The conflict only occurs
+    # on case-insensitive file systems, as typically used on macOS machines.
+    conflicts("@:6", when="platform=darwin %apple-clang@7:")
+    conflicts("@:6", when="platform=darwin %clang@7:")
+
+    @property
+    def charmarch(self):
+        plat = sys.platform
+
+        if plat.startswith("linux"):
+            plat = "linux"
+        elif plat.startswith("win"):
+            plat = "win"
+        elif plat.startswith("cnl"):
+            plat = "cnl"
+        elif plat.startswith("cnk"):
+            plat = "cnk"
+
+        mach = platform.machine()
+
+        if mach.startswith("ppc"):
+            mach = "ppc"
+        elif mach.startswith("arm"):
+            mach = "arm"
+
+        comm = self.spec.variants["backend"].value
+
+        # Define Charm++ version names for various (plat, mach, comm)
+        # combinations. Note that not all combinations are supported.
+        versions = {
+            ("darwin", "x86_64", "mpi"): "mpi-darwin-x86_64",
+            ("darwin", "x86_64", "multicore"): "multicore-darwin-x86_64",
+            ("darwin", "x86_64", "netlrts"): "netlrts-darwin-x86_64",
+            ("linux", "x86_64", "mpi"): "mpi-linux-x86_64",
+            ("linux", "x86_64", "multicore"): "multicore-linux-x86_64",
+            ("linux", "x86_64", "netlrts"): "netlrts-linux-x86_64",
+            ("linux", "x86_64", "verbs"): "verbs-linux-x86_64",
+            ("linux", "x86_64", "ofi"): "ofi-linux-x86_64",
+            ("linux", "ppc", "mpi"): "mpi-linux-ppc",
+            ("linux", "ppc", "multicore"): "multicore-linux-ppc",
+            ("linux", "ppc", "netlrts"): "netlrts-linux-ppc",
+            ("linux", "ppc", "pami"): "pami-linux-ppc64le",
+            ("linux", "ppc", "verbs"): "verbs-linux-ppc64le",
+            ("linux", "arm", "netlrts"): "netlrts-linux-arm7",
+            ("linux", "aarch64", "netlrts"): "netlrts-linux-arm8",
+            ("win", "x86_64", "mpi"): "mpi-win-x86_64",
+            ("win", "x86_64", "multicore"): "multicore-win-x86_64",
+            ("win", "x86_64", "netlrts"): "netlrts-win-x86_64",
+            ("cnl", "x86_64", "gni"): "gni-crayxc",
+            ("cnl", "x86_64", "mpi"): "mpi-crayxc",
+        }
+
+        if self.spec.satisfies("@6.10:"):
+            versions.update(
+                {
+                    ("linux", "x86_64", "ucx"): "ucx-linux-x86_64",
+                    ("linux", "aarch64", "ucx"): "ucx-linux-arm8",
+                }
+            )
+
+        # Some versions were renamed/removed in 6.11
+        if self.spec.version < Version("6.11.0"):
+            versions.update(
+                {
+                    ("linux", "i386", "mpi"): "mpi-linux",
+                    ("linux", "i386", "multicore"): "multicore-linux",
+                    ("linux", "i386", "netlrts"): "netlrts-linux",
+                    ("linux", "i386", "uth"): "uth-linux",
+                    ("linux", "arm", "multicore"): "multicore-arm7",
+                    ("linux", "aarch64", "multicore"): "multicore-arm8",
+                }
+            )
+        else:
+            versions.update(
+                {
+                    ("linux", "i386", "mpi"): "mpi-linux-i386",
+                    ("linux", "i386", "multicore"): "multicore-linux-i386",
+                    ("linux", "i386", "netlrts"): "netlrts-linux-i386",
+                    ("linux", "arm", "multicore"): "multicore-linux-arm7",
+                    ("linux", "aarch64", "multicore"): "multicore-linux-arm8",
+                }
+            )
+
+        if self.spec.satisfies("@7:"):
+            versions.update(
+                {
+                    ("linux", "arm", "mpi"): "mpi-linux-arm7",
+                    ("linux", "aarch64", "mpi"): "mpi-linux-arm8",
+                    ("darwin", "arm", "multicore"): "multicore-darwin-arm8",
+                    ("darwin", "arm", "netlrts"): "netlrts-darwin-arm8",
+                    ("darwin", "arm", "mpi"): "mpi-darwin-arm8",
+                }
+            )
+
+            if self.spec.satisfies("backend=ofi pmi=cray-pmi"):
+                versions.update(
+                    {
+                        ("linux", "x86_64", "ofi"): "ofi-crayshasta",
+                        ("linux", "aarch64", "ofi"): "ofi-crayshasta",
+                    }
+                )
+
+        if (plat, mach, comm) not in versions:
+            raise InstallError(
+                "The communication mechanism %s is not supported "
+                "on a %s platform with a %s CPU" % (comm, plat, mach)
+            )
+
+        return versions[(plat, mach, comm)]
+
+    # FIXME: backend=mpi also provides mpi, but spack does not support
+    # depends_on("mpi") and provides("mpi") in the same package currently.
+    # for b in ['multicore', 'netlrts', 'verbs', 'gni', 'ofi', 'pami',
+    #          'pamilrts']:
+    #    provides('mpi@2', when='@6.7.1:
+    #            build-target=AMPI backend={0}'.format(b))
+    #    provides('mpi@2', when='@6.7.1:
+    #            build-target=LIBS backend={0}'.format(b))
+
+    def install(self, spec, prefix):
+        if not ("backend=mpi" in self.spec) or not ("backend=netlrts" in self.spec):
+            if "+pthreads" in self.spec:
+                raise InstallError(
+                    "The pthreads option is only\
+                                    available on the Netlrts and MPI \
+                                    network layers."
+                )
+
+        if (
+            ("backend=ucx" in self.spec)
+            or ("backend=ofi" in self.spec)
+            or ("backend=gni" in self.spec)
+        ):
+            if "pmi=none" in self.spec:
+                raise InstallError(
+                    "The UCX/OFI/GNI backends need \
+                                    PMI to run. Please add pmi=... \
+                                    Note that PMIx is the preferred \
+                                    option."
+                )
+
+        if (
+            ("pmi=simplepmi" in self.spec)
+            or ("pmi=slurmpmi" in self.spec)
+            or ("pmi=slurmpmi2" in self.spec)
+        ):
+            if "^openmpi" in self.spec:
+                raise InstallError(
+                    "To use any process management \
+                                    interface other than PMIx, \
+                                    a non OpenMPI based MPI must be \
+                                    present on the system"
+                )
+
+        target = spec.variants["build-target"].value
+        builddir = prefix
+
+        # We assume that Spack's compiler wrappers make this work. If
+        # not, then we need to query the compiler vendor from Spack
+        # here.
+        options = [os.path.basename(self.compiler.cc)]
+
+        if "@:6.8.2 %aocc" not in spec:
+            options.append(os.path.basename(self.compiler.fc))
+
+        options.append("-j%d" % make_jobs)
+        options.append("--destination=%s" % builddir)
+
+        if "pmi=slurmpmi" in spec:
+            options.append("slurmpmi")
+        if "pmi=slurmpmi2" in spec:
+            options.append("slurmpmi2")
+        if "pmi=pmix" in spec:
+            options.append("ompipmix")
+            options.extend(["--basedir=%s" % spec["openmpi"].prefix])
+
+        if "backend=mpi" in spec:
+            # in intelmpi <prefix>/include and <prefix>/lib fails so --basedir
+            # cannot be used
+            options.extend(
+                ["--incdir={0}".format(incdir) for incdir in spec["mpi"].headers.directories]
+            )
+            options.extend(
+                ["--libdir={0}".format(libdir) for libdir in spec["mpi"].libs.directories]
+            )
+
+        if "backend=ucx" in spec:
+            options.extend(["--basedir=%s" % spec["ucx"].prefix])
+        if "+papi" in spec:
+            options.extend(["papi", "--basedir=%s" % spec["papi"].prefix])
+        if "+smp" in spec and "backend=multicore" not in spec:
+            # The 'multicore' backend always uses SMP, so we don't have to
+            # append the 'smp' option when the 'multicore' backend is active. As
+            # of Charm++ v7.0.0 it is actually a build error to append 'smp'
+            # with the 'multicore' backend.
+            options.append("smp")
+        if "+tcp" in spec:
+            if "backend=netlrts" not in spec:
+                # This is a Charm++ limitation; it would lead to a
+                # build error
+                raise InstallError(
+                    "The +tcp variant requires " "the backend=netlrts communication mechanism"
+                )
+            options.append("tcp")
+        if "+omp" in spec:
+            options.append("omp")
+        if "+pthreads" in spec:
+            options.append("pthreads")
+        if "+cuda" in spec:
+            options.append("cuda")
+
+        if "+shared" in spec:
+            options.append("--build-shared")
+        if "+production" in spec:
+            options.append("--with-production")
+        if "+tracing" in spec:
+            options.append("--enable-tracing")
+
+        # Call "make" via the build script
+        # Note: This builds Charm++ in the "tmp" subdirectory of the
+        # install directory. Maybe we could set up a symbolic link
+        # back to the build tree to prevent this? Alternatively, we
+        # could dissect the build script; the build instructions say
+        # this wouldn't be difficult.
+        build = Executable(join_path(".", "build"))
+        build(target, self.charmarch, *options)
+
+        # Charm++'s install script does not copy files, it only creates
+        # symbolic links. Fix this.
+        for dirpath, dirnames, filenames in os.walk(builddir):
+            for filename in filenames:
+                filepath = join_path(dirpath, filename)
+                if os.path.islink(filepath):
+                    tmppath = filepath + ".tmp"
+                    # Skip dangling symbolic links
+                    try:
+                        copy(filepath, tmppath)
+                        os.remove(filepath)
+                        os.rename(tmppath, filepath)
+                    except (IOError, OSError):
+                        pass
+
+        tmp_path = join_path(builddir, "tmp")
+        if not os.path.islink(tmp_path):
+            shutil.rmtree(tmp_path)
+
+        if self.spec.satisfies("@6.9.99"):
+            # A broken 'doc' link in the prefix can break the build.
+            # Remove it and replace it if it is broken.
+            try:
+                os.stat(prefix.doc)
+            except OSError:
+                os.remove(prefix.doc)
+                mkdirp(prefix.doc)
+
+    @run_after("install")
+    @on_package_attributes(run_tests=True)
+    def check_build(self):
+        make(
+            "-C",
+            join_path(self.stage.source_path, "tests"),
+            "test",
+            "TESTOPTS=++local",
+            parallel=False,
+        )
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        if not self.spec.satisfies("backend=mpi"):
+            env.set("MPICC", self.prefix.bin.ampicc)
+            env.set("MPICXX", self.prefix.bin.ampicxx)
+            env.set("MPIF77", self.prefix.bin.ampif77)
+            env.set("MPIF90", self.prefix.bin.ampif90)
+
+    def setup_dependent_package(self, module, dependent_spec):
+        self.spec.mpicc = self.prefix.bin.ampicc
+        self.spec.mpicxx = self.prefix.bin.ampicxx
+        self.spec.mpifc = self.prefix.bin.ampif90
+        self.spec.mpif77 = self.prefix.bin.ampif77
+        self.spec.charmarch = self.charmarch + "-smp" if self.spec.satisfies("+smp") else ""

--- a/recipes/namd/3.0/gh200/repo/packages/charmpp/strictpass.patch
+++ b/recipes/namd/3.0/gh200/repo/packages/charmpp/strictpass.patch
@@ -1,0 +1,16 @@
+--- old/src/scripts/configure
++++ new/src/scripts/configure
+@@ -2146,13 +2146,6 @@
+ 	test_result $? "$1" "$2" "$3"
+  	strictpass=$pass
+ 	strictfail=$fail
+-        if test $pass -eq 1
+-	then
+- 	  if cat out | grep -i "warn" > /dev/null 2>&1
+-	  then
+-	    strictpass="0" && strictfail="1"
+-          fi
+-        fi
+ 	cat out >> $charmout
+ 	/bin/rm -f out
+ }

--- a/recipes/namd/3.0/gh200/repo/packages/namd/inherited-member-2.13.patch
+++ b/recipes/namd/3.0/gh200/repo/packages/namd/inherited-member-2.13.patch
@@ -1,0 +1,18 @@
+--- a/src/colvarproxy_namd.C	2020-09-04 12:07:22.649591658 -0700
++++ b/src/colvarproxy_namd.C	2020-09-04 12:08:41.724079519 -0700
+@@ -479,13 +479,13 @@
+ 
+ // Callback functions
+ 
++#ifdef NAMD_TCL
+ void colvarproxy_namd::init_tcl_pointers()
+ {
+-#ifdef NAMD_TCL
+   // Store pointer to NAMD's Tcl interpreter
+   _tcl_interp = reinterpret_cast<void *>(Node::Object()->getScript()->interp);
+-#endif
+ }
++#endif
+ 
+ int colvarproxy_namd::run_force_callback()
+ {

--- a/recipes/namd/3.0/gh200/repo/packages/namd/inherited-member-2.14.patch
+++ b/recipes/namd/3.0/gh200/repo/packages/namd/inherited-member-2.14.patch
@@ -1,0 +1,16 @@
+--- a/src/colvarproxy_namd.C	2020-10-02 15:11:37.205197956 -0700
++++ b/src/colvarproxy_namd.C	2020-10-02 15:11:47.865071117 -0700
+@@ -94,12 +94,11 @@
+           "the output restart file could be defined, exiting.\n");
+   }
+ 
++  init_tcl_pointers();
+ 
+ #ifdef NAMD_TCL
+   have_scripts = true;
+ 
+-  init_tcl_pointers();
+-
+   // See is user-scripted forces are defined
+   if (Tcl_FindCommand(reinterpret_cast<Tcl_Interp *>(tcl_interp_),
+                       "calc_colvar_forces", NULL, 0) == NULL) {

--- a/recipes/namd/3.0/gh200/repo/packages/namd/namd-python38.patch
+++ b/recipes/namd/3.0/gh200/repo/packages/namd/namd-python38.patch
@@ -1,0 +1,17 @@
+diff -Naur spack-src/config spack-src.patched/config
+--- spack-src/config	2020-08-05 13:51:21.000000000 -0400
++++ spack-src.patched/config	2021-12-30 17:59:44.574264378 -0500
+@@ -501,7 +501,12 @@
+       echo "Using $PYTHON_CONFIG to configure Python."
+       PYTHON_PREFIX=$($PYTHON_CONFIG --prefix)
+       PYTHON_INCFLAGS=$($PYTHON_CONFIG --includes)
+-      PYTHON_LDFLAGS=$($PYTHON_CONFIG --ldflags)
++      # Payerle 2021-12-30: python@3.8 python-config omits -lpython unless --embed given
++      # Try first with embed, and if fails, try w/out embed
++      PYTHON_LDFLAGS=$($PYTHON_CONFIG --ldflags --embed)
++      if echo "$PYTHON_LDFLAGS" | grep -q '^Usage'; then
++	      PYTHON_LDFLAGS=$($PYTHON_CONFIG --ldflags)
++      fi
+       if ! echo "$PYTHON_LDFLAGS" | grep -q -- '-L'; then
+         echo "$PYTHON_CONFIG did not return a -L flag: using Anaconda?"
+         if [ -d "$PYTHON_PREFIX/lib" ]; then

--- a/recipes/namd/3.0/gh200/repo/packages/namd/package.py
+++ b/recipes/namd/3.0/gh200/repo/packages/namd/package.py
@@ -1,0 +1,313 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+import platform
+import sys
+
+import llnl.util.tty as tty
+
+from spack.package import *
+
+
+class Namd(MakefilePackage, CudaPackage):
+    """NAMD is a parallel molecular dynamics code designed for
+    high-performance simulation of large biomolecular systems."""
+
+    homepage = "https://www.ks.uiuc.edu/Research/namd/"
+    url = "file://{0}/NAMD_2.12_Source.tar.gz".format(os.getcwd())
+    git = "https://charm.cs.illinois.edu/gerrit/namd.git"
+    manual_download = True
+    redistribute(source=False, binary=False)
+
+    maintainers("jcphill")
+
+    version("master", branch="master")
+    version("3.0", sha256="301c64f0f1db860f7336efdb26223ccf66b5ab42bfc9141df8d81ec1e20bf472")
+    version("3.0b7", sha256="b18ff43b0f55ec59e137c62eba1812589dd88b2122c3a05ea652781667f438b4", deprecated=True)
+    version("3.0b6", sha256="8b5fb1dc8d5b5666c6a45d20ee7e8c9d1f5c186578e2cf148b68ba421d43b850", deprecated=True)
+    version("3.0b3", sha256="20c32b6161f9c376536e3cb97c3bfe5367e1baaaace3c716ff79831fc2eb8199", deprecated=True)
+    version("2.15a2", sha256="8748cbaa93fc480f92fc263d9323e55bce6623fc693dbfd4a40f59b92669713e", deprecated=True)
+    version("2.15a1", branch="master", tag="release-2-15-alpha-1", deprecated=True)
+    # Same as above, but lets you use a local file instead of git
+    version(
+        "2.15a1.manual", sha256="474006e98e32dddae59616b3b75f13a2bb149deaf7a0d617ce7fb9fd5a56a33a", deprecated=True
+    )
+    version(
+        "2.14",
+        sha256="34044d85d9b4ae61650ccdba5cda4794088c3a9075932392dd0752ef8c049235",
+        preferred=True,
+    )
+    version("2.13", md5="9e3323ed856e36e34d5c17a7b0341e38")
+    version("2.12", md5="2a1191909b1ab03bf0205971ad4d8ee9")
+
+    variant(
+        "fftw",
+        default="3",
+        values=("none", "2", "3", "mkl", "amdfftw"),
+        description="Enable the use of FFTW/FFTW3/MKL FFT/AMDFFTW",
+    )
+
+    variant(
+        "interface",
+        default="tcl",
+        values=("none", "tcl", "python"),
+        description="Enables Tcl and/or python interface",
+    )
+
+    variant("avxtiles", when="target=x86_64_v4:", default=False, description="Enable avxtiles")
+    variant("single_node_gpu", default=False, description="Single node GPU")
+
+    # init_tcl_pointers() declaration and implementation are inconsistent
+    # "src/colvarproxy_namd.C", line 482: error: inherited member is not
+    # allowed
+    patch("inherited-member-2.13.patch", when="@2.13")
+    patch("inherited-member-2.14.patch", when="@2.14")
+    # Handle change in python-config for python@3.8:
+    patch("namd-python38.patch", when="interface=python ^python@3.8:")
+
+    depends_on("charmpp@7.0.0:", when="@3.0:")
+    depends_on("charmpp@6.10.1:6", when="@2.14:2")
+    depends_on("charmpp@6.8.2", when="@2.13")
+    depends_on("charmpp@6.7.1", when="@2.12")
+
+    depends_on("fftw@:2", when="fftw=2")
+    depends_on("fftw@3:", when="fftw=3")
+
+    depends_on("amdfftw", when="fftw=amdfftw")
+
+    depends_on("mkl", when="fftw=mkl")
+
+    depends_on("tcl", when="interface=tcl")
+
+    depends_on("tcl", when="interface=python")
+    depends_on("python", when="interface=python")
+
+    conflicts("+avxtiles", when="@:2.14,3:", msg="AVXTiles algorithm requires NAMD 2.15")
+
+    # https://www.ks.uiuc.edu/Research/namd/2.12/features.html
+    # https://www.ks.uiuc.edu/Research/namd/2.13/features.html
+    # https://www.ks.uiuc.edu/Research/namd/2.14/features.html
+    depends_on("cuda@6.5.14:7.5.18", when="@2.12 +cuda")
+    depends_on("cuda@8.0.61:", when="@2.13: +cuda")
+
+    def _copy_arch_file(self, lib):
+        config_filename = "arch/{0}.{1}".format(self.arch, lib)
+        if self.arch == "linux-aarch64":
+            copy("arch/Linux-ARM64.{0}".format(lib), config_filename)
+        else:
+            copy("arch/Linux-x86_64.{0}".format(lib), config_filename)
+
+        if lib == "tcl":
+            filter_file(
+                r"-ltcl8\.5", "-ltcl{0}".format(self.spec["tcl"].version.up_to(2)), config_filename
+            )
+
+    def _append_option(self, opts, lib):
+        if lib != "python":
+            self._copy_arch_file(lib)
+        spec = self.spec
+        lib_prefix = (
+            spec[lib].package.component_prefix
+            if spec[lib].name == "intel-oneapi-mkl"
+            else spec[lib].prefix
+        )
+        opts.extend(["--with-{0}".format(lib), "--{0}-prefix".format(lib), lib_prefix])
+
+    @property
+    def arch(self):
+        plat = sys.platform
+        if plat.startswith("linux"):
+            plat = "linux"
+        march = platform.machine()
+        return "{0}-{1}".format(plat, march)
+
+    @property
+    def build_directory(self):
+        return "{0}-spack".format(self.arch)
+
+    def _edit_arch_generic(self, spec, prefix):
+        """Generic arch makefile generation"""
+        m64 = "-m64 " if not spec.satisfies("arch=aarch64:") else ""
+        with working_dir("arch"):
+            with open("{0}.arch".format(self.build_directory), "w") as fh:
+                # this options are take from the default provided
+                # configuration files
+                # https://github.com/UIUC-PPL/charm/pull/2778
+                archopt = spec.architecture.target.optimization_flags(spec.compiler)
+
+                if self.spec.satisfies("^charmpp@:6.10.1"):
+                    optims_opts = {
+                        "gcc": m64
+                        + "-O3 -fexpensive-optimizations \
+                                        -ffast-math -lpthread "
+                        + archopt,
+                        "intel": "-O2 -ip -qopenmp-simd" + archopt,
+                        "clang": m64 + "-O3 -ffast-math -fopenmp " + archopt,
+                        "aocc": m64
+                        + "-O3 -ffp-contract=fast -ffast-math \
+                                        -fopenmp "
+                        + archopt,
+                    }
+                else:
+                    optims_opts = {
+                        "gcc": m64
+                        + "-O3 -fexpensive-optimizations \
+                                        -ffast-math -lpthread "
+                        + archopt,
+                        "intel": "-O2 -ip " + archopt,
+                        "clang": m64 + "-O3 -ffast-math -fopenmp " + archopt,
+                        "aocc": m64
+                        + "-O3 -ffp-contract=fast \
+                                        -ffast-math "
+                        + archopt,
+                    }
+
+                if self.spec.satisfies("+avxtiles"):
+                    optims_opts["aocc"] += " -DNAMD_AVXTILES"
+                    optims_opts["clang"] += " -DNAMD_AVXTILES"
+                    optims_opts["gcc"] += " -DNAMD_AVXTILES"
+                    optims_opts["intel"] += " -DNAMD_AVXTILES"
+
+                optim_opts = (
+                    optims_opts[self.compiler.name] if self.compiler.name in optims_opts else ""
+                )
+
+                fh.write(
+                    "\n".join(
+                        [
+                            "NAMD_ARCH = {0}".format(self.arch),
+                            "CHARMARCH = {0}".format(self.spec["charmpp"].charmarch),
+                            "CXX = {0.cxx} {0.cxx11_flag}".format(self.compiler),
+                            "CXXOPTS = {0}".format(optim_opts),
+                            "CC = {0}".format(self.compiler.cc),
+                            "COPTS = {0}".format(optim_opts),
+                            "",
+                        ]
+                    )
+                )
+
+    def _edit_arch_target_based(self, spec, prefix):
+        """Try to use target base arch file return True if succeed"""
+        if spec.version < Version("2.14"):
+            return False
+
+        found_special_opt = False
+        with working_dir("arch"):
+            arch_filename = "{0}.arch".format(self.build_directory)
+
+            replace = [
+                [r"^CHARMARCH = .*$", "CHARMARCH = {0}".format(self.spec["charmpp"].charmarch)],
+                [r"^NAMD_ARCH = .*$", "NAMD_ARCH = {0}".format(self.arch)],
+            ]
+
+            # Optimizations for skylake_avx512
+            if (
+                spec.platform == "linux"
+                and self.compiler.name == "intel"
+                and "avx512" in spec.target
+                and spec.target >= "skylake_avx512"
+            ):
+                if spec.version >= Version("2.15") and os.path.exists("Linux-AVX512-icc.arch"):
+                    tty.info("Building binaries with AVX512-tile optimization")
+                    copy("Linux-AVX512-icc.arch", arch_filename)
+                elif spec.version >= Version("2.14") and os.path.exists("Linux-SKX-icc.arch"):
+                    tty.info("Building binaries with Skylake-X" "AVX512 optimization")
+                    copy("Linux-SKX-icc.arch", arch_filename)
+                else:
+                    return False
+
+                replace.append([r"^CXX = icpc", "CXX = {0}".format(self.compiler.cxx)])
+                replace.append([r"^CC = icc", "CC = {0}".format(self.compiler.cc)])
+                found_special_opt = True
+
+            if found_special_opt:
+                for pattern, replacement in replace:
+                    filter_file(pattern, replacement, arch_filename)
+
+        return found_special_opt
+
+    def _edit_arch(self, spec, prefix):
+        """Try to use target base arch file, if not make generic"""
+        if not self._edit_arch_target_based(spec, prefix):
+            self._edit_arch_generic(spec, prefix)
+
+    def edit(self, spec, prefix):
+        self._edit_arch(spec, prefix)
+
+        self._copy_arch_file("base")
+
+        opts = ["--charm-base", spec["charmpp"].prefix]
+        fftw_version = spec.variants["fftw"].value
+        if fftw_version == "none":
+            opts.append("--without-fftw")
+        elif fftw_version == "mkl":
+            self._append_option(opts, "mkl")
+        elif fftw_version == "amdfftw":
+            self._copy_arch_file("fftw3")
+            opts.extend(["--with-fftw3", "--fftw-prefix", spec["amdfftw"].prefix])
+        else:
+            _fftw = "fftw{0}".format("" if fftw_version == "2" else "3")
+
+            self._copy_arch_file(_fftw)
+            opts.extend(["--with-{0}".format(_fftw), "--fftw-prefix", spec["fftw"].prefix])
+
+        interface_type = spec.variants["interface"].value
+        if interface_type != "none":
+            self._append_option(opts, "tcl")
+
+            if interface_type == "python":
+                self._append_option(opts, "python")
+        else:
+            opts.extend(["--without-tcl", "--without-python"])
+
+        if "+cuda" in spec:
+            self._append_option(opts, "cuda")
+            filter_file(
+                "^CUDADIR=.*$",
+                "CUDADIR={0}".format(spec["cuda"].prefix),
+                join_path("arch", self.arch + ".cuda"),
+            )
+            for cuda_arch in spec.variants["cuda_arch"].value:
+                opts.extend(["--cuda-gencode", f"arch=compute_{cuda_arch},code=sm_{cuda_arch}"])
+
+            if "+single_node_gpu" in spec:
+                opts.extend(["--with-single-node-cuda"])
+
+        config = Executable("./config")
+
+        config(self.build_directory, *opts)
+
+        # patch Make.config if needed
+        # spack install charmpp straight to prefix
+        # (not to $(CHARMBASE)/$(CHARMARCH))
+        if not os.path.exists(
+            join_path(self.spec["charmpp"].prefix, self.spec["charmpp"].charmarch)
+        ):
+            filter_file(
+                r"^CHARM = \$\(CHARMBASE\)/\$\(CHARMARCH\)",
+                "CHARM = $(CHARMBASE)",
+                join_path(self.build_directory, "Make.config"),
+            )
+
+    @when("@3.0b3")
+    def build(self, spec, prefix):
+        # Disable parallel build
+        # https://github.com/spack/spack/pull/43215
+        with working_dir(self.build_directory):
+            make(parallel=False)
+
+    def install(self, spec, prefix):
+        with working_dir(self.build_directory):
+            mkdirp(prefix.bin)
+            if spec.version < Version("3"):
+                install("namd2", prefix.bin)
+            else:
+                install("namd3", prefix.bin)
+            install("psfgen", prefix.bin)
+
+            # I'm not sure this is a good idea or if an autoload of the charm
+            # module would not be better.
+            install("charmrun", prefix.bin)


### PR DESCRIPTION
Add NAMD `3.0`, the fist official release of `3.x`, using Charm++ `8.0.0` as backend.

This is still a single-node build, but the name of the views have been changed in preparation for a multi-node build: `namd-single-node` and `develop-single-node`.

Installation instructions have been updated to use Charm++ 8.0.0, bundled with NAMD 3.0. Additionally, an optional section on how to build a CPU-only version had been added. Apparently for cpHMD simulations both a CPU and GPU version are needed at the same time.