### PR TITLE
NAMD 3.0 (GH200): use tcl@8.6 and add multi-node build (with MPI) 

### DIFF
--- a/docs/uenv-namd.md
+++ b/docs/uenv-namd.md
@@ -1,14 +1,10 @@
 # NAMD
 
-[NAMD] is a parallel molecular dynamics code based on [Charm++] designed for high-performance simulation of large biomolecular systems.
+[NAMD] is a parallel molecular dynamics code based on [Charm++], designed for high-performance simulation of large biomolecular systems.
 
 !!! danger "Licensing Terms and Conditions"
     
     [NAMD] is distributed free of charge for research purposes only and not for commercial use: users must agree to [NAMD license] in order to use it at [CSCS]. Users agree to acknowledge use of [NAMD] in any reports or publications of results obtained with the Software (see [NAMD Homepage] for details).
-
-!!! warning
-
-    Currently, we only provide single-GPU and single-node multi-GPU [NAMD] builds, which greatly benefit from the new GPU-resident mode providing very fast dynamics (see [NAME 3.0 new features]). If you require a multi-node version of [NAMD], please contact us.
 
 ## Single-node build
 
@@ -18,6 +14,11 @@ The single-node build works on a single node and benefits from the new GPU-resid
 * `develop-single-node` (development view, without NAMD)
 
 ### Building from source
+
+!!! warning "TCL Version"
+    According to the NAMD 3.0 release notes, TCL `8.6` is required. However, the source code for the `3.0` release still contains hard-coded
+    flags for TCL `8.5`. The UENV provides `tcl@8.6`, therefore you need to manually modify NAMD 3.0's `arch/Linux-ARM64.tcl` file as follows:
+    change `-ltcl8.5` to `-ltcl8.6` in the definition of the `TCLLIB` variable.
 
 The [NAMD] `uenv` provides all the dependencies required to build [NAMD] from source. You can follow these steps to build [NAMD] from source:
 
@@ -33,9 +34,15 @@ cd <PATH_TO_NAMD_SOURCE>
 # Set variable VIEW_PATH to the view
 export DEV_VIEW_PATH=/user-environment/env/${DEV_VIEW_NAME}
 
+
 # Build bundled Charm++
 tar -xvf charm-8.0.0.tar && cd charm-8.0.0
 ./build charm++ multicore-linux-arm8 gcc --with-production --enable-tracing -j 32
+
+# ~~~~~
+# Modify the "arch/Linux-ARM64.tcl" file now!
+# Change "-ltcl8.5" with "-ltcl8.6" in the definition of the "TCLLIB" variable
+# ~~~~~
 
 # Configure NAMD build for GPU
 cd .. 
@@ -51,6 +58,80 @@ cd Linux-ARM64-g++.cuda && make -j 32
 cd ..
 ./config Linux-ARM64-g++ \
     --charm-arch multicore-linux-arm8-gcc --charm-base $PWD/charm-8.0.0 \
+    --with-tcl --tcl-prefix ${DEV_VIEW_PATH} \
+    --with-fftw --with-fftw3 --fftw-prefix ${DEV_VIEW_PATH}
+cd Linux-ARM64-g++ && make -j 32
+# !!! END OPTIONAL !!!
+
+cd ..
+export LD_LIBRARY_PATH=${DEV_VIEW_PATH}/lib/
+
+# Run NAMD (GPU version)
+Linux-ARM64-g++.cuda/namd3 <NAMD_OPTIONS>
+
+# !!! BEGIN OPTIONAL !!!
+# Run NAMD (CPU version)
+Linux-ARM64-g++/namd3 <NAMD_OPTIONS>
+# !!! END OPTIONAL !!!
+```
+
+The optional section provides instructions on how to build a CPU-only build, should you need it (for constant pH MD simulations, for example).
+
+## Multi-node build
+
+The multi-node build works on multiple nodes and it is based on [Charm++] MPI backend. The multi-node build provides the following views:
+
+* `namd`
+* `develop` (development view, without NAMD)
+
+!!! note "GPU-resident mode"
+    The multi-node build based on [Charm++] MPI backend can't take advantage of the new GPU-resident mode. Unless you require the multi-node
+    build or you can prove it is faster for your use case, we recommend using the single-node build with the GPU-resident mode.
+    
+### Building from source
+
+!!! warning "TCL Version"
+    According to the NAMD 3.0 release notes, TCL `8.6` is required. However, the source code for the `3.0` release still contains hard-coded
+    flags for TCL `8.5`. The UENV provides `tcl@8.6`, therefore you need to manually modify NAMD 3.0's `arch/Linux-ARM64.tcl` file as follows:
+    change `-ltcl8.5` to `-ltcl8.6` in the definition of the `TCLLIB` variable.
+
+The [NAMD] `uenv` provides all the dependencies required to build [NAMD] from source. You can follow these steps to build [NAMD] from source:
+
+```bash
+export DEV_VIEW_NAME="develop"
+
+# Start uenv and load develop view
+uenv start <NAMD_UENV>
+uenv view ${DEV_VIEW_NAME}
+
+cd <PATH_TO_NAMD_SOURCE>
+
+# Set variable VIEW_PATH to the view
+export DEV_VIEW_PATH=/user-environment/env/${DEV_VIEW_NAME}
+
+# Build bundled Charm++
+tar -xvf charm-8.0.0.tar && cd charm-8.0.0
+env MPICXX=mpicxx ./build charm++ mpi-linux-arm8 smp --with-production -j 32
+
+# ~~~~~
+# Modify the "arch/Linux-ARM64.tcl" file now!
+# Change "-ltcl8.5" with "-ltcl8.6" in the definition of the "TCLLIB" variable
+# ~~~~~
+
+# Configure NAMD build for GPU
+cd .. 
+./config Linux-ARM64-g++.cuda \
+    --charm-arch mpi-linux-arm8-smp --charm-base $PWD/charm-8.0.0 \
+    --with-tcl --tcl-prefix ${DEV_VIEW_PATH} \
+    --with-fftw --with-fftw3 --fftw-prefix ${DEV_VIEW_PATH} \
+    --cuda-gencode arch=compute_90,code=sm_90 --with-single-node-cuda --with-cuda --cuda-prefix ${DEV_VIEW_PATH}
+cd Linux-ARM64-g++.cuda && make -j 32
+
+# !!! BEGIN OPTIONAL !!!
+# Configure NAMD build for CPU
+cd ..
+./config Linux-ARM64-g++ \
+    --charm-arch mpi-linux-arm8-smp --charm-base $PWD/charm-8.0.0 \
     --with-tcl --tcl-prefix ${DEV_VIEW_PATH} \
     --with-fftw --with-fftw3 --fftw-prefix ${DEV_VIEW_PATH}
 cd Linux-ARM64-g++ && make -j 32

--- a/docs/uenv-namd.md
+++ b/docs/uenv-namd.md
@@ -29,20 +29,19 @@ export DEV_VIEW_NAME="develop-single-node"
 uenv start <NAMD_UENV>
 uenv view ${DEV_VIEW_NAME}
 
-cd <PATH_TO_NAMD_SOURCE>
-
 # Set variable VIEW_PATH to the view
 export DEV_VIEW_PATH=/user-environment/env/${DEV_VIEW_NAME}
 
+cd <PATH_TO_NAMD_SOURCE>
+
+# ~~~~~
+# Modify the "<PATH_TO_NAMD_SOURCE>/arch/Linux-ARM64.tcl" file now!
+# Change "-ltcl8.5" with "-ltcl8.6" in the definition of the "TCLLIB" variable
+# ~~~~~
 
 # Build bundled Charm++
 tar -xvf charm-8.0.0.tar && cd charm-8.0.0
 ./build charm++ multicore-linux-arm8 gcc --with-production --enable-tracing -j 32
-
-# ~~~~~
-# Modify the "arch/Linux-ARM64.tcl" file now!
-# Change "-ltcl8.5" with "-ltcl8.6" in the definition of the "TCLLIB" variable
-# ~~~~~
 
 # Configure NAMD build for GPU
 cd .. 
@@ -104,19 +103,19 @@ export DEV_VIEW_NAME="develop"
 uenv start <NAMD_UENV>
 uenv view ${DEV_VIEW_NAME}
 
-cd <PATH_TO_NAMD_SOURCE>
-
 # Set variable VIEW_PATH to the view
 export DEV_VIEW_PATH=/user-environment/env/${DEV_VIEW_NAME}
 
-# Build bundled Charm++
-tar -xvf charm-8.0.0.tar && cd charm-8.0.0
-env MPICXX=mpicxx ./build charm++ mpi-linux-arm8 smp --with-production -j 32
+cd <PATH_TO_NAMD_SOURCE>
 
 # ~~~~~
 # Modify the "arch/Linux-ARM64.tcl" file now!
 # Change "-ltcl8.5" with "-ltcl8.6" in the definition of the "TCLLIB" variable
 # ~~~~~
+
+# Build bundled Charm++
+tar -xvf charm-8.0.0.tar && cd charm-8.0.0
+env MPICXX=mpicxx ./build charm++ mpi-linux-arm8 smp --with-production -j 32
 
 # Configure NAMD build for GPU
 cd .. 

--- a/recipes/namd/3.0/gh200/compilers.yaml
+++ b/recipes/namd/3.0/gh200/compilers.yaml
@@ -2,4 +2,4 @@ bootstrap:
   spec: gcc@12
 gcc:
   specs:
-  - gcc@12.3.0
+  - gcc@12.3

--- a/recipes/namd/3.0/gh200/environments.yaml
+++ b/recipes/namd/3.0/gh200/environments.yaml
@@ -1,12 +1,12 @@
 namd-single-node:
   compiler:
   - toolchain: gcc
-    spec: gcc@12.3.0
+    spec: gcc@12.3
   unify: true
   specs:
-  - cuda@12.4.0
+  - cuda@12.4
   - fftw@3.3.10 +openmp ~mpi
-  - tcl@8.5
+  - tcl@8.6
   - charmpp@=8.0.0 backend=multicore +production +tracing
   - namd@=3.0 +cuda cuda_arch=90 +single_node_gpu
   views:
@@ -14,4 +14,24 @@ namd-single-node:
       link: roots
       exclude: ["namd"]
     namd-single-node:
+      link: roots
+namd:
+  compiler:
+  - toolchain: gcc
+    spec: gcc@12.3
+  unify: true
+  specs:
+  - cuda@12.4
+  - fftw@3.3.10 +openmp
+  - tcl@8.6
+  - charmpp@=8.0.0 backend=mpi +production +tracing ^cray-mpich
+  - namd@=3.0 +cuda cuda_arch=90
+  mpi:
+    spec: cray-mpich@8.1.30
+    gpu: cuda
+  views:
+    develop:
+      link: roots
+      exclude: ["namd"]
+    namd:
       link: roots

--- a/recipes/namd/3.0/gh200/environments.yaml
+++ b/recipes/namd/3.0/gh200/environments.yaml
@@ -13,8 +13,14 @@ namd-single-node:
     develop-single-node:
       link: roots
       exclude: ["namd"]
+      uenv:
+        prefix_paths:
+          LD_LIBRARY_PATH: [lib, lib64]
     namd-single-node:
       link: roots
+      uenv:
+        prefix_paths:
+          LD_LIBRARY_PATH: [lib, lib64]
 namd:
   compiler:
   - toolchain: gcc
@@ -33,5 +39,11 @@ namd:
     develop:
       link: roots
       exclude: ["namd"]
+      uenv:
+        prefix_paths:
+          LD_LIBRARY_PATH: [lib, lib64]
     namd:
       link: roots
+      uenv:
+        prefix_paths:
+          LD_LIBRARY_PATH: [lib, lib64]


### PR DESCRIPTION
* GPU-resident mode requires `tcl@8.6` (see 3.0 release notes)
  * This was not the case/not documented in the `3.0b6` release
  * ARM64 arch files still hard-code `-ltcl8.5` so the build instructions have been updated accordingly
* Provide multi-node build with MPI backend
  * Charm++ MPI backend was not possible to use with `3.0b6` but it is now available
  * Added instructions to build the multi-node version (with Charm++ MPI backend) from source