### PR TITLE
build hdf5 with mpi and fortran

### DIFF
--- a/recipes/prgenv-gnu/24.7/gh200/environments.yaml
+++ b/recipes/prgenv-gnu/24.7/gh200/environments.yaml
@@ -12,7 +12,7 @@ gcc-env:
   - cuda@12.4
   - fftw
   - fmt
-  - hdf5+hl
+  - hdf5+hl+mpi+fortran
   - libtree
   - meson
   - nccl


### PR DESCRIPTION
add `+mpi+fortran` to `hdf5` as requested by a user.