### PR TITLE
add netcdf to prgenv-gnu/24.11

### DIFF
--- a/recipes/prgenv-gnu/24.11/a100/environments.yaml
+++ b/recipes/prgenv-gnu/24.11/a100/environments.yaml
@@ -21,6 +21,9 @@ gcc-env:
   - libtree
   - lz4
   - meson
+  - netcdf-c
+  - netcdf-cxx
+  - netcdf-fortran
   - ninja
   - openblas threads=openmp
   - osu-micro-benchmarks@5.9

--- a/recipes/prgenv-gnu/24.11/gh200/environments.yaml
+++ b/recipes/prgenv-gnu/24.11/gh200/environments.yaml
@@ -21,6 +21,9 @@ gcc-env:
   - libtree
   - lz4
   - meson
+  - netcdf-c
+  - netcdf-cxx
+  - netcdf-fortran
   - ninja
   - openblas threads=openmp
   - osu-micro-benchmarks@5.9

--- a/recipes/prgenv-gnu/24.11/mc/environments.yaml
+++ b/recipes/prgenv-gnu/24.11/mc/environments.yaml
@@ -21,6 +21,9 @@ gcc-env:
   - libtree
   - lz4
   - meson
+  - netcdf-c
+  - netcdf-cxx
+  - netcdf-fortran
   - ninja
   - openblas threads=openmp
   - osu-micro-benchmarks@5.9


### PR DESCRIPTION
... because it is often the only thing stopping users from using the prgenv-gny uenv