### PR TITLE
editors v25.3, incl nnn, py-ranger-fm

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -96,6 +96,15 @@ uenvs:
         eiger: [zen2]
         todi: [gh200]
       mount: "/user-tools"
+    "25.3":
+      recipes:
+        zen2: "25.3"
+        zen3: "25.3"
+        gh200: "25.3"
+      deploy:
+        eiger: [zen2]
+        todi: [gh200]
+      mount: "/user-tools"
   gromacs:
     "2023":
       recipes:

--- a/recipes/editors/25.3/compilers.yaml
+++ b/recipes/editors/25.3/compilers.yaml
@@ -1,0 +1,5 @@
+bootstrap:
+  spec: gcc@12.3
+gcc:
+  specs:
+  - gcc@12.3

--- a/recipes/editors/25.3/compilers.yaml
+++ b/recipes/editors/25.3/compilers.yaml
@@ -1,5 +1,5 @@
 bootstrap:
-  spec: gcc@12.3
+  spec: gcc@12
 gcc:
   specs:
-  - gcc@12.3
+  - gcc@12

--- a/recipes/editors/25.3/config.yaml
+++ b/recipes/editors/25.3/config.yaml
@@ -1,0 +1,6 @@
+name: editors
+store: /user-tools
+spack:
+  commit: releases/v0.23
+  repo: https://github.com/spack/spack.git
+description: text editors and handy command line tools

--- a/recipes/editors/25.3/environments.yaml
+++ b/recipes/editors/25.3/environments.yaml
@@ -1,0 +1,44 @@
+editors:
+  compiler:
+      - toolchain: gcc
+        spec: gcc
+  unify: true
+  mpi: null
+  specs:
+  # the editors
+  - emacs +treesitter
+  - nano
+  - vim +python +lua
+  - neovim
+  # additional tools that integrate well with tools
+  - direnv
+  - fd
+  - go
+  - lazygit
+  - lua
+  - node-js
+  # python 3.12 was breaking the build of vim
+  - python@3.11
+  - ripgrep
+  - screen
+  - rust
+  - tree-sitter
+  # required to fix a broken link for the latest 0.3.3
+  #- libvterm@0.3.1
+  # filebrowser
+  - py-ranger-fm
+  - nnn
+  - tmux
+  packages:
+  # libvterm does not build with libtool pulled from a build cache
+  - libtool
+  - curl
+  - gmake
+  - perl
+  - git
+  views:
+    ed:
+      link: roots
+      uenv:
+        prefix_paths:
+          LD_LIBRARY_PATH: [lib, lib64]

--- a/recipes/editors/25.3/environments.yaml
+++ b/recipes/editors/25.3/environments.yaml
@@ -6,7 +6,7 @@ editors:
   mpi: null
   specs:
   # the editors
-  - emacs +treesitter
+  - emacs +treesitter +native
   - nano
   - vim +python +lua
   - neovim

--- a/recipes/editors/25.3/environments.yaml
+++ b/recipes/editors/25.3/environments.yaml
@@ -29,6 +29,8 @@ editors:
   - py-ranger-fm
   - nnn
   - tmux
+  # cmdline fuzzy finder
+  - fzf
   packages:
   # libvterm does not build with libtool pulled from a build cache
   - libtool

--- a/recipes/editors/25.3/modules.yaml
+++ b/recipes/editors/25.3/modules.yaml
@@ -1,0 +1,23 @@
+modules:
+  # Paths to check when creating modules for all module sets
+  prefix_inspections:
+    bin:
+      - PATH
+    lib:
+      - LD_LIBRARY_PATH
+    lib64:
+      - LD_LIBRARY_PATH
+
+  default:
+    arch_folder: false
+    # Where to install modules
+    roots:
+      tcl: /snap/modules
+    tcl:
+      all:
+        autoload: none
+      hash_length: 0
+      exclude_implicits: true
+      exclude: ['%gcc@7.5.0', 'gcc %gcc@7.5.0']
+      projections:
+        all: '{name}'

--- a/recipes/editors/25.3/repo/packages/nnn/package.py
+++ b/recipes/editors/25.3/repo/packages/nnn/package.py
@@ -1,0 +1,94 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Nnn(MakefilePackage):
+    """nnn (n³) is a full-featured terminal file manager.
+    It's tiny, nearly 0-config and incredibly fast."""
+
+    homepage = "https://github.com/jarun/nnn"
+    url = "https://github.com/jarun/nnn/archive/refs/tags/v5.0.tar.gz"
+
+    maintainers("fthaler")
+
+    license("BSD-2-Clause", checked_by="fthaler")
+
+    version("5.0", sha256="31e8fd85f3dd7ab2bf0525c3c0926269a1e6d35a5343a6714315642370d8605a")
+
+    depends_on("binutils", type="build")
+
+    depends_on("coreutils")
+    depends_on("file")
+    depends_on("git", when="+gitstatus")
+    depends_on("ncurses")
+    depends_on("pcre", when="+pcre")
+    depends_on("readline", when="+readline")
+    depends_on("sed")
+    depends_on("tar")
+    depends_on("zip")
+
+    variant("mouse", default=True, description="Enable mouse support")
+    variant(
+        "pcre",
+        default=False,
+        description="Use Perl Compatible Regular Expressions (default is POSIX)",
+    )
+    variant("readline", default=True, description="Compile with readline")
+    variant(
+        "icons",
+        values=("none", "emoji", "nerd", "icons-in-terminal"),
+        default="emoji",
+        description="Choose the icons to use "
+        "(see https://github.com/jarun/nnn/wiki/Advanced-use-cases#file-icons)",
+    )
+
+    variant("colemak", default=False, description="Key bindings for Colemak keyboard layout")
+    variant("gitstatus", default=True, description="Add git status column to the detail view")
+    variant("namefirst", default=False, description="Print filenames first in the detail view")
+    variant(
+        "restorepreview",
+        default=False,
+        description="Add pipe to close and restore preview-tui for internal undetached edits",
+    )
+
+    def setup_build_environment(self, env):
+        spec = self.spec
+        env.set("PREFIX", self.prefix)
+        if "+pcre" in spec:
+            env.append_flags("CPPFLAGS", spec["pcre"].headers.include_flags)
+            env.append_flags("LDFLAGS", spec["pcre"].libs.ld_flags)
+
+    @property
+    def build_targets(self):
+        spec = self.spec
+        targets = []
+        if "~mouse" in spec:
+            targets.append("O_NOMOUSE=1")
+        if "+pcre" in spec:
+            targets.append("O_PCRE=1")
+        if "~readline" in spec:
+            targets.append("O_NORL=1")
+
+        if "icons=emoji" in spec:
+            targets.append("O_EMOJI=1")
+        elif "icons=nerd" in spec:
+            targets.append("O_NERD=1")
+        elif "icons=icons-in-terminal" in spec:
+            targets.append("O_ICONS=1")
+
+        if "+colemak" in spec:
+            targets.append("O_COLEMAK=1")
+        if "+gitstatus" in spec:
+            targets.append("O_GITSTATUS=1")
+        if "+namefirst" in spec:
+            targets.append("O_NAMEFIRST=1")
+        if "+restorepreview" in spec:
+            targets.append("O_RESTOREPREVIEW=1")
+        return targets
+
+    @property
+    def install_targets(self):
+        return self.build_targets + ["strip", "install"]


### PR DESCRIPTION
`nnn` (filemanager) has disappeared from eiger. Also add py-ranger-fm (another filemanager) to the image.