### PR TITLE
update prgenv-gnu view in reframe.yaml

### DIFF
--- a/recipes/prgenv-gnu/24.11/gh200/extra/reframe.yaml
+++ b/recipes/prgenv-gnu/24.11/gh200/extra/reframe.yaml
@@ -9,4 +9,4 @@ default:
   cxx: mpic++
   ftn: mpifort
   views:
-    - develop
+    - default


### PR DESCRIPTION
[prgenv-gnu/24.11/gh200/extra/reframe.yaml](https://github.com/eth-cscs/alps-uenv/blob/main/recipes/prgenv-gnu/24.11/gh200/extra/reframe.yaml#L11) sets the default view to:

```
  views:
    - develop 
```

but the views are: 
```
  views:
    spack: configure spack upstream
    modules: activate modules
    default:
```

This pr updates reframe.yaml