### PR TITLE
CP2K 2025.1

### DIFF
--- a/recipes/cp2k/2025.1/gh200/environments.yaml
+++ b/recipes/cp2k/2025.1/gh200/environments.yaml
@@ -1,4 +1,7 @@
 cp2k:
+  # NOTE: In the "cp2k" environment, DLA-Future is not used by CP2K
+  # NOTE: However, DLA-Future is still included in the "cp2k" environment
+  # NOTE: This is to ensure dependencies are the same and mudule names do no clash
   compiler:
   - toolchain: gcc
     spec: gcc@12.3
@@ -46,10 +49,10 @@ cp2k:
   # SIRIUS
   - hdf5
   - spfft
-  - sirius +dlaf +elpa +scalapack
+  - sirius +elpa ~dlaf +scalapack
   # CP2K
   - dbcsr@2.8.0
-  - cp2k@2025.1 +libxc +libint +spglib +cosma +spla +elpa +dlaf +sirius +plumed +dftd4 lmax=5 build_system=cmake
+  - cp2k@2025.1 +libxc +libint +spglib +cosma +spla +elpa ~dlaf +sirius +plumed +dftd4 lmax=5 build_system=cmake
   variants:
     - +mpi
     - +openmp
@@ -64,4 +67,71 @@ cp2k:
       link: roots
       exclude: ["cp2k"]
     cp2k:
+      link: roots
+cp2k-dlaf:
+  compiler:
+  - toolchain: gcc
+    spec: gcc@12.3
+  unify: true
+  specs:
+  - cmake
+  - ninja
+  - cuda@12.4 # Can't be newer than driver version, for DBCSR
+  - openblas threads=openmp
+  - netlib-scalapack
+  - fftw
+  - libxc@7 ~cuda build_system=cmake
+  - spglib
+  - spla
+  - elpa
+  - plumed
+  # libint
+  - libint
+  - eigen@3
+  # pika
+  - pika@0.30.1 malloc=mimalloc
+  - mimalloc
+  - boost
+  - fmt
+  - spdlog
+  - hwloc
+  - whip
+  # Umpire
+  - umpire
+  - blt
+  - camp
+  # DLA-Future
+  - dla-future@0.7.3 +mpi_gpu_aware +mpi_gpu_force_contiguous +scalapack +miniapps
+  - blaspp
+  - lapackpp
+  - dla-future-fortran
+  # DFTD4
+  - dftd4
+  - multicharge
+  - mctc-lib
+  # COSMA
+  - tiled-mm
+  - costa
+  - cosma +gpu_direct
+  # SIRIUS
+  - hdf5
+  - spfft
+  - sirius ~elpa +dlaf +scalapack
+  # CP2K
+  - dbcsr@2.8.0
+  - cp2k@2025.1 +libxc +libint +spglib +cosma +spla +dlaf ~elpa +sirius +plumed +dftd4 lmax=5 build_system=cmake
+  variants:
+    - +mpi
+    - +openmp
+    - +cuda
+    - cuda_arch=90
+    - build_type=Release
+  mpi:
+    spec: cray-mpich@8.1.30
+    gpu: cuda
+  views:
+    develop-dlaf:
+      link: roots
+      exclude: ["cp2k"]
+    cp2k-dlaf:
       link: roots

--- a/recipes/cp2k/2025.1/gh200/extra/reframe.yaml
+++ b/recipes/cp2k/2025.1/gh200/extra/reframe.yaml
@@ -8,6 +8,17 @@ develop:
   ftn: mpifort
   views:
     - develop
+develop:
+  features:
+    - cp2k-dev
+    - cuda
+    - mpi
+    - dlaf
+  cc: mpicc
+  cxx: mpic++
+  ftn: mpifort
+  views:
+    - develop-dlaf
 modules:
   features:
     - cp2k-dev
@@ -30,3 +41,14 @@ run:
   ftn: mpifort
   views:
     - cp2k
+run-dlaf:
+  features:
+    - cp2k
+    - cuda
+    - mpi
+    - dlaf
+  cc: mpicc
+  cxx: mpic++
+  ftn: mpifort
+  views:
+    - cp2k-dlaf

--- a/recipes/cp2k/2025.1/gh200/modules.yaml
+++ b/recipes/cp2k/2025.1/gh200/modules.yaml
@@ -19,3 +19,7 @@ modules:
       exclude: ['%gcc@7.5.0', 'gcc %gcc@7.5.0']
       projections:
         all: '{name}/{version}'
+        cp2k~dlaf: '{name}/{version}'
+        cp2k+dlaf: '{name}-dlaf/{version}'
+        sirius~dlaf: '{name}/{version}'
+        sirius+dlaf: '{name}-dlaf/{version}'

--- a/recipes/cp2k/2025.1/mc/environments.yaml
+++ b/recipes/cp2k/2025.1/mc/environments.yaml
@@ -1,4 +1,7 @@
 cp2k:
+  # NOTE: In the "cp2k" environment, DLA-Future is not used by CP2K
+  # NOTE: However, DLA-Future is still included in the "cp2k" environment
+  # NOTE: This is to ensure dependencies are the same and mudule names do no clash
   compiler:
   - toolchain: gcc
     spec: gcc@12.3
@@ -40,10 +43,10 @@ cp2k:
   # SIRIUS
   - hdf5
   - spfft
-  - sirius +dlaf +elpa +scalapack
+  - sirius ~dlaf +elpa +scalapack
   # CP2K
   - dbcsr@2.8.0
-  - cp2k@2025.1 +libxc +libint +spglib +cosma +spla +elpa +dlaf +sirius +plumed +dftd4 lmax=5 build_system=cmake
+  - cp2k@2025.1 +libxc +libint +spglib +cosma +spla +elpa ~dlaf +sirius +plumed +dftd4 lmax=5 build_system=cmake
   variants:
     - +mpi
     - +openmp
@@ -57,4 +60,64 @@ cp2k:
       link: roots
       exclude: ["cp2k"]
     cp2k:
+      link: roots
+cp2k-dlaf:
+  compiler:
+  - toolchain: gcc
+    spec: gcc@12.3
+  unify: true
+  specs:
+  - cmake
+  - ninja
+  - openblas threads=openmp
+  - netlib-scalapack
+  - fftw
+  - libxc@7 build_system=cmake
+  - spglib
+  - spla
+  - elpa
+  - libxsmm
+  - plumed
+  # libint
+  - libint
+  - eigen@3
+  # pika
+  - pika@0.30.1 malloc=mimalloc
+  - mimalloc
+  - boost
+  - fmt
+  - spdlog
+  - hwloc
+  # DLA-Future
+  - dla-future@0.7.3 +scalapack +miniapps
+  - blaspp
+  - lapackpp
+  - dla-future-fortran
+  # DFTD4
+  - dftd4
+  - multicharge
+  - mctc-lib
+  # COSMA
+  - costa
+  - cosma
+  # SIRIUS
+  - hdf5
+  - spfft
+  - sirius +dlaf ~elpa +scalapack
+  # CP2K
+  - dbcsr@2.8.0
+  - cp2k@2025.1 +libxc +libint +spglib +cosma +spla ~elpa +dlaf +sirius +plumed +dftd4 lmax=5 build_system=cmake
+  variants:
+    - +mpi
+    - +openmp
+    - build_type=Release
+    - ~cuda
+    - ~rocm
+  mpi:
+    spec: cray-mpich@8.1.30
+  views:
+    develop-dlaf:
+      link: roots
+      exclude: ["cp2k"]
+    cp2k-dlaf:
       link: roots

--- a/recipes/cp2k/2025.1/mc/modules.yaml
+++ b/recipes/cp2k/2025.1/mc/modules.yaml
@@ -19,3 +19,7 @@ modules:
       exclude: ['%gcc@7.5.0', 'gcc %gcc@7.5.0']
       projections:
         all: '{name}/{version}'
+        cp2k~dlaf: '{name}/{version}'
+        cp2k+dlaf: '{name}-dlaf/{version}'
+        sirius~dlaf: '{name}/{version}'
+        sirius+dlaf: '{name}-dlaf/{version}'


### PR DESCRIPTION
Fix some issues with CP2K+DLAF by separating the `cp2k+dlaf` integration in a standalone view.