### PR TITLE
[CP2K] Remove "-" from ReFrame feature name

### DIFF
--- a/recipes/cp2k/2025.1/gh200/extra/reframe.yaml
+++ b/recipes/cp2k/2025.1/gh200/extra/reframe.yaml
@@ -1,6 +1,6 @@
 develop:
   features:
-    - cp2k-dev
+    - cp2kdev
     - cuda
     - mpi
   cc: mpicc
@@ -10,7 +10,7 @@ develop:
     - develop
 develop:
   features:
-    - cp2k-dev
+    - cp2kdev
     - cuda
     - mpi
     - dlaf
@@ -21,7 +21,7 @@ develop:
     - develop-dlaf
 modules:
   features:
-    - cp2k-dev
+    - cp2kdev
     - cuda
     - mpi
   cc: mpicc

--- a/recipes/cp2k/2025.1/mc/extra/reframe.yaml
+++ b/recipes/cp2k/2025.1/mc/extra/reframe.yaml
@@ -1,6 +1,6 @@
 develop:
   features:
-    - cp2k-dev
+    - cp2kdev
     - mpi
   cc: mpicc
   cxx: mpic++
@@ -9,7 +9,7 @@ develop:
     - develop
 modules:
   features:
-    - cp2k-dev
+    - cp2kdev
     - mpi
   cc: mpicc
   cxx: mpic++


### PR DESCRIPTION
Using `-` for the ReFrame feature `cp2k-dev` seems to prevent disabling some features (`+cp2k-dev -dlaf`). This PR changes `cp2k-dev` to `cp2kdev` so that `+cp2kdev -dlaf` works as expected in ReFrame.