### PR TITLE
sirius 7.8 / nlcglib 1.3

### DIFF
--- a/recipes/q-e-sirius/v1.0.1/gh200/environments.yaml
+++ b/recipes/q-e-sirius/v1.0.1/gh200/environments.yaml
@@ -8,7 +8,8 @@ gcc-env:
   unify: true
   specs:
   - q-e-sirius@1.0.1 hdf5=parallel
-  - sirius@7.7.1
+  - sirius@7.8 +nlcglib
+  - nlcglib@1.3.0
   - spfft+gpu_direct
   variants:
   - cuda_arch=90

--- a/recipes/q-e-sirius/v1.0.1/gh200/environments.yaml
+++ b/recipes/q-e-sirius/v1.0.1/gh200/environments.yaml
@@ -8,7 +8,7 @@ gcc-env:
   unify: true
   specs:
   - q-e-sirius@1.0.1 hdf5=parallel
-  - sirius@7.8 +nlcglib
+  - sirius@7.8 +nlcglib +cuda
   - nlcglib@1.3.0
   - spfft+gpu_direct
   variants:

--- a/recipes/q-e-sirius/v1.0.1/mc/environments.yaml
+++ b/recipes/q-e-sirius/v1.0.1/mc/environments.yaml
@@ -7,7 +7,8 @@ gcc-env:
   unify: when_possible
   specs:
   - q-e-sirius@1.0.1 hdf5=parallel
-  - sirius@7.7.1
+  - sirius@7.8 +nlcglib
+  - nlcglib@1.3.0
   variants:
   - +mpi
   views:

--- a/recipes/q-e-sirius/v1.0.1/mc/extra/reframe.yaml
+++ b/recipes/q-e-sirius/v1.0.1/mc/extra/reframe.yaml
@@ -1,0 +1,11 @@
+modules:
+  features:
+    - mpi
+    - q-e-sirius
+  cc: mpicc
+  cxx: mpic++
+  ftn: mpifort
+  views:
+    - modules
+  activation:
+    - module load q-e-sirius

--- a/recipes/q-e-sirius/v1.0.1/repo/packages/nlcglib/package.py
+++ b/recipes/q-e-sirius/v1.0.1/repo/packages/nlcglib/package.py
@@ -49,7 +49,7 @@ class Nlcglib(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("googletest", type="build", when="+tests")
     depends_on("nlohmann-json")
     depends_on("kokkos@4:", when="@1.1:")
-    depends_on("fmt", when="@develop")
+    depends_on("fmt", when="@1.3:")
 
     # MKLConfig.cmake introduced in 2021.3
     conflicts("intel-oneapi-mkl@:2021.2", when="^intel-oneapi-mkl")

--- a/recipes/q-e-sirius/v1.0.1/repo/packages/nlcglib/package.py
+++ b/recipes/q-e-sirius/v1.0.1/repo/packages/nlcglib/package.py
@@ -18,6 +18,7 @@ class Nlcglib(CMakePackage, CudaPackage, ROCmPackage):
     license("BSD-3-Clause")
 
     version("develop", branch="develop")
+    version("1.3.0", sha256="d6adfe97407be2ecf41eda6f530e9724052f5298c5f884113969a9204530a745")
     version("1.2.0", sha256="bb3676472cf7cc9effe06e416ecf4ef38e6c58c3e423dc70b8b6b32890bc89f2")
     version("1.1.0", sha256="9e7c2eea84a5ce191bd9af08f6c890717f7b6e88be7bd15cfe774eb0e0dabd8a")
     version("1.0b", sha256="086c46f06a117f267cbdf1df4ad42a8512689a9610885763f463469fb15e82dc")

--- a/recipes/q-e-sirius/v1.0.1/repo/packages/sirius/package.py
+++ b/recipes/q-e-sirius/v1.0.1/repo/packages/sirius/package.py
@@ -22,6 +22,7 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
     version("develop", branch="develop")
     version("master", branch="master")
 
+    version("7.8.0", sha256="2cd2f98d35fb9e0a8f6d68714c6f8d682895781d564e91ef6685d92569ffd413")
     version("7.7.1", sha256="6039c84197d9e719e826f98b840cff19bc513887b443f97c0099d3c8b908efed")
     version("7.7.0", sha256="be0bdc76db9eb8afdcb950f0ccaf7535b8e85d72a4232dc92246f54fa68d9d7b")
     version("7.6.2", sha256="1ba92942aa39b49771677cc8bf1c94a0b4350eb45bf3009318a6c2350b46a276")


### PR DESCRIPTION
Update `sirius` `7.7.1` -> `7.8.0`, new nlcglib version.

To be deployed as `q-e-sirius/1.0.1:v2`.