### PR TITLE
Fix view of prgenv-gnu/24.11/mc

### DIFF
--- a/recipes/prgenv-gnu/24.11/mc/extra/reframe.yaml
+++ b/recipes/prgenv-gnu/24.11/mc/extra/reframe.yaml
@@ -1,7 +1,11 @@
 default:
-  features: [osu-micro-benchmarks, mpi, serial, openmp]
+  features:
+    - mpi
+    - osu-micro-benchmarks
+    - openmp
+    - serial
   cc: mpicc
   cxx: mpic++
   ftn: mpifort
   views:
-    - develop
+    - default


### PR DESCRIPTION
There's no develop view in that uenv, moving to default