### PR TITLE
Add `prgenv` reframe feature to prgenv-nvfortran

### DIFF
--- a/recipes/prgenv-nvfortran/25.7/gh200/extra/reframe.yaml
+++ b/recipes/prgenv-nvfortran/25.7/gh200/extra/reframe.yaml
@@ -2,10 +2,11 @@ default:
   features:
     - cuda
     - mpi
-    - osu-micro-benchmarks
-    - openmp
-    - serial
     - nvhpc
+    - openmp
+    - osu-micro-benchmarks
+    - prgenv
+    - serial
   cc: mpicc
   cxx: mpic++
   ftn: mpifort


### PR DESCRIPTION
The `prgenv` feature is used in cscs-reframe-tests for "generic" tests that don't need to be run for application-specific uenvs, but should be run for the base "programming environment"-like uenvs.

E.g. the CUDA samples test filters for the `prgenv` feature: https://github.com/eth-cscs/cscs-reframe-tests/blob/225f906d2bbab7273d29035a0b1d77c0bfd5d208/checks/prgenv/cuda/cuda_samples.py#L87.

Additionally, cscs-reframe-tests automatically adds the `prgenv` feature for uenvs whose name start with `prgenv` (https://github.com/eth-cscs/cscs-reframe-tests/blob/225f906d2bbab7273d29035a0b1d77c0bfd5d208/config/utilities/uenv.py#L134-L135), but this detection only works when declaring uenvs to be tested by name (`UENV=prgenv-...`) instead of by path (`UENV=/path/to/squashfs`).

The more reliable way of exposing the feature is to simply set it explicitly in reframe.yaml, as I've done here.

I'm also adding the `prgenv` feature to prgenv-gnu/25.6 in https://github.com/eth-cscs/alps-uenv/pull/224.