### PR TITLE
Remove develop fields from `config.yaml`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -67,7 +67,6 @@ uenvs:
         a100: mch/climana/24.7
       deploy:
         balfrin: [zen3, a100]
-      develop: False
   climana:
     "24.10":
       recipes:
@@ -76,7 +75,6 @@ uenvs:
         a100: mch/climana/24.10
       deploy:
         balfrin: [zen3, a100]
-      develop: False
   editors:
     "24.7":
       recipes:
@@ -106,7 +104,6 @@ uenvs:
       deploy:
         # deploy to both the production and test clusters
         eiger: [zen2]
-      develop: False
     "2024":
       recipes:
         zen2: 2024/mc
@@ -123,7 +120,6 @@ uenvs:
         zen2: 2024.1/mc
       deploy:
         eiger: [zen2]
-      develop: False
     "2024.2":
       recipes:
         gh200: 2024.2/gh200
@@ -135,7 +131,6 @@ uenvs:
       deploy:
         daint: [gh200]
         eiger: [zen2]
-      develop: False
     "2025.1":
       recipes:
         gh200: 2025.1/gh200
@@ -143,7 +138,6 @@ uenvs:
       deploy:
         daint: [gh200]
         eiger: [zen2]
-      develop: False
   icon-wcp:
     "v1":
       recipes:
@@ -151,14 +145,12 @@ uenvs:
         gh200: wcp/icon/v1/gh200
       deploy:
         santis: [gh200]
-      develop: False
   julia:
     "24.9":
       recipes:
         zen2:  "24.9/mc"
         zen3:  "24.9/mc"
         gh200: "24.9/gh200"
-      develop: False
     "25.5":
       recipes:
         gh200: "25.5/gh200"
@@ -168,7 +160,6 @@ uenvs:
         santis: [gh200]
         daint: [gh200]
         clariden: [gh200]
-      develop: False
   lammps:
     "2023":
       recipes:
@@ -176,7 +167,6 @@ uenvs:
         zen3: "2023/mc"
       deploy:
         eiger: [zen2]
-      develop: False
     "2024":
       recipes:
         zen2: "2024/mc"
@@ -185,7 +175,6 @@ uenvs:
       deploy:
         daint: [gh200]
         eiger: [zen2]
-      develop: False
   linalg:
     "24.11":
       recipes:
@@ -195,7 +184,6 @@ uenvs:
       deploy:
         daint: [gh200]
         eiger: [zen2]
-      develop: False
   linalg-complex:
     "24.11":
       recipes:
@@ -205,7 +193,6 @@ uenvs:
       deploy:
         daint: [gh200]
         eiger: [zen2]
-      develop: False
   linaro-forge:
     "25.0":
       recipes:
@@ -216,7 +203,6 @@ uenvs:
         daint: [gh200]
         santis: [gh200]
         clariden: [gh200]
-      develop: False
       mount: "/user-tools"
     "24.1.2":
       recipes:
@@ -228,7 +214,6 @@ uenvs:
         daint: [gh200]
         santis: [gh200]
         clariden: [gh200]
-      develop: False
       mount: "/user-tools"
     "24.1.1":
       recipes:
@@ -240,7 +225,6 @@ uenvs:
         daint: [gh200]
         santis: [gh200]
         clariden: [gh200]
-      develop: False
       mount: "/user-tools"
   mch:
     "v7":
@@ -248,13 +232,11 @@ uenvs:
         a100: v7
       deploy:
         balfrin: [a100]
-      develop: False
     "v8":
       recipes:
         a100: v8
       deploy:
         balfrin: [a100]
-      develop: False
   namd:
     "3.0":
       recipes:
@@ -263,7 +245,6 @@ uenvs:
       deploy:
         daint: [gh200]
         eiger: [zen2]
-      develop: False
   netcdf-tools:
     "2024":
       recipes:
@@ -274,7 +255,6 @@ uenvs:
       deploy:
         eiger: [zen2]
         balfrin: [zen3]
-      develop: False
   # OpenFOAM Foundation
   openfoam-org:
     "8":
@@ -321,7 +301,6 @@ uenvs:
         daint: [gh200]
         santis: [gh200]
         eiger: [zen2]
-      develop: True
   prgenv-nvfortran:
     "24.11":
       recipes:
@@ -379,7 +358,6 @@ uenvs:
     "v7.5":
       recipes:
         a100: v7.5/a100
-      develop: True
   q-e-sirius:
     "v1.0.1":
       recipes:
@@ -409,13 +387,11 @@ uenvs:
         gh200: v6.4.2/gh200
       deploy:
         daint: [gh200]
-      develop: False
     "v6.4.3":
       recipes:
         gh200: v6.4.3/gh200
       deploy:
         daint: [gh200]
-      develop: False
     "v6.5.0":
       recipes:
         gh200: v6.5.0/gh200
@@ -423,7 +399,6 @@ uenvs:
       deploy:
         daint: [gh200]
         eiger: [zen2]
-      develop: False
   jupyterlab:
     "v4.1.8":
       recipes:
@@ -445,4 +420,3 @@ uenvs:
         clariden: [gh200]
         santis: [gh200]
         eiger: [zen2]
-      develop: True


### PR DESCRIPTION
This is nowadas detected based on recipe version instead.