### PR TITLE
Don't exclude gcc module in `prgenv-gnu`

### DIFF
--- a/recipes/prgenv-gnu/25.6/gh200/modules.yaml
+++ b/recipes/prgenv-gnu/25.6/gh200/modules.yaml
@@ -18,6 +18,6 @@ modules:
         autoload: none
       hash_length: 0
       exclude_implicits: true
-      exclude: ['%gcc@12.3.0']
+      exclude: []
       projections:
         all: '{name}/{version}'

--- a/recipes/prgenv-gnu/25.6/mc/modules.yaml
+++ b/recipes/prgenv-gnu/25.6/mc/modules.yaml
@@ -18,6 +18,6 @@ modules:
         autoload: none
       hash_length: 0
       exclude_implicits: true
-      exclude: ['%gcc@12.3.0']
+      exclude: []
       projections:
         all: '{name}/{version}'


### PR DESCRIPTION
When going from prgenv-gnu/24.11 to 25.6, I blindly updated the `exclude` field for modules to exclude the newer system compiler. After the bootstrapping was removed, this excludes the actual compiler we want to expose as a module. I think we can get away without excluding any specific modules. Only the correct `gcc` is considered at least in the case of prgenv-gnu/25.6 even when the exclude field is empty.