### PR TITLE
Make sure qe reframe activations have cuda available

### DIFF
--- a/recipes/q-e-sirius/v1.0.1/gh200/environments.yaml
+++ b/recipes/q-e-sirius/v1.0.1/gh200/environments.yaml
@@ -11,6 +11,7 @@ gcc-env:
   - sirius@7.8 +nlcglib +cuda
   - nlcglib@1.3.0+gpu_direct
   - spfft+gpu_direct
+  - cuda
   variants:
   - cuda_arch=90
   views:

--- a/recipes/q-e-sirius/v1.0.1/gh200/extra/reframe.yaml
+++ b/recipes/q-e-sirius/v1.0.1/gh200/extra/reframe.yaml
@@ -9,4 +9,4 @@ modules:
   views:
     - modules
   activation:
-    - module load q-e-sirius
+    - module load q-e-sirius cuda

--- a/recipes/quantumespresso/v7.4.1/gh200/extra/reframe.yaml
+++ b/recipes/quantumespresso/v7.4.1/gh200/extra/reframe.yaml
@@ -21,4 +21,4 @@ modules:
   views:
     - modules
   activation:
-    - module load quantum-espresso
+    - module load quantum-espresso nvhpc


### PR DESCRIPTION
I noticed the qe (quantumespresso and q-e-sirius) uenvs advertise the `cuda` reframe feature, but they don't load cuda (or nvhpc) in the activation part. This means that generic reframe tests that check for the cuda feature (and expect e.g. nvcc to be available) will fail.

I'm proposing to add cuda (nvhpc for quantumespresso, because that's in the root specs; maybe cuda is better to load?) so that the cuda feature can correctly be relied on.

Alternatives:
- don't advertise the cuda feature at all (but this feels wrong, because I guess reframe tests might want to check for e.g. `+qe +cuda` to determine if cuda features are enabled for qe)
- load the default view

I'm not planning to rebuild the uenvs now, but want to update these for the next time the uenvs get updated.