### PR TITLE
Normalize cuda_arch for GH200

### DIFF
--- a/recipes/prgenv-gnu/25.6/gh200/environments.yaml
+++ b/recipes/prgenv-gnu/25.6/gh200/environments.yaml
@@ -37,7 +37,7 @@ gcc-env:
   variants:
   - +mpi
   - +cuda
-  - cuda_arch=90a
+  - cuda_arch=90
   views:
     default:
       link: roots


### PR DESCRIPTION
The recipe `prgenv-gnu/25.6/gh200` is the only one using `cuda_arch=90a` instead of `cuda_arch=90`.

What's the right one?

I think this might become problematic as soon as we will be more explicit with external specs defined in https://github.com/eth-cscs/alps-cluster-config so I'm trying to normalize them.