### PR TITLE
prgenv-llvm

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -336,6 +336,14 @@ uenvs:
         daint: [gh200]
         santis: [gh200]
         eiger: [zen2]
+  prgenv-llvm:
+    "25.11":
+      recipes:
+        gh200: 25.11/gh200
+      deploy:
+        clariden: [gh200]
+        daint: [gh200]
+        santis: [gh200]
   prgenv-nvfortran:
     "24.11":
       recipes:

--- a/recipes/prgenv-llvm/25.11/gh200/compilers.yaml
+++ b/recipes/prgenv-llvm/25.11/gh200/compilers.yaml
@@ -1,0 +1,4 @@
+gcc:
+  version: "14"
+llvm:
+  version: "18" # AdaptiveCPP/hipSYCL currently requires at most LLVM 18

--- a/recipes/prgenv-llvm/25.11/gh200/config.yaml
+++ b/recipes/prgenv-llvm/25.11/gh200/config.yaml
@@ -1,0 +1,10 @@
+name: prgenv-gnu
+spack:
+  repo: https://github.com/spack/spack.git
+  commit: v1.1.1
+  packages:
+    repo: https://github.com/spack/spack-packages.git
+    commit: 7178c89f9bb9bb96f692325509e9348f243b9a0a # develop on 2026-03-09
+store: /user-environment
+description: LLVM Compiler toolchain with cray-mpich, Python, CMake and other development tools.
+version: 2

--- a/recipes/prgenv-llvm/25.11/gh200/environments.yaml
+++ b/recipes/prgenv-llvm/25.11/gh200/environments.yaml
@@ -2,7 +2,7 @@ llvm-env:
   compiler: [llvm]
   network:
       mpi: cray-mpich@8.1.32 +cuda
-  unify: true
+  unify: when_possible
   duplicates:
     strategy: full
   specs:

--- a/recipes/prgenv-llvm/25.11/gh200/environments.yaml
+++ b/recipes/prgenv-llvm/25.11/gh200/environments.yaml
@@ -39,7 +39,7 @@ llvm-env:
   - gdrcopy%gcc
   - cuda@12
   - xcb-util-cursor
-  - aws-ofi-nccl%gcc
+  - aws-ofi-nccl@1.17 %gcc
   - superlu%gcc
   variants:
   - +mpi

--- a/recipes/prgenv-llvm/25.11/gh200/environments.yaml
+++ b/recipes/prgenv-llvm/25.11/gh200/environments.yaml
@@ -1,7 +1,7 @@
 llvm-env:
   compiler: [llvm]
   network:
-      mpi: cray-mpich@8.1.32 +cuda
+      mpi: cray-mpich@8.1.32%llvm +cuda
   unify: when_possible
   duplicates:
     strategy: full
@@ -34,12 +34,13 @@ llvm-env:
   - zlib-ng
   # add GPU-specific packages here, for easier comparison with mc version
   - hipsycl
-  - nccl
-  - nccl-tests
+  - nccl%gcc
+  - nccl-tests%gcc
+  - gdrcopy%gcc
   - cuda@12
   - xcb-util-cursor
   - aws-ofi-nccl
-  - superlu
+  - superlu%gcc
   variants:
   - +mpi
   - +cuda

--- a/recipes/prgenv-llvm/25.11/gh200/environments.yaml
+++ b/recipes/prgenv-llvm/25.11/gh200/environments.yaml
@@ -1,7 +1,7 @@
 llvm-env:
   compiler: [llvm]
   network:
-      mpi: cray-mpich@8.1.32 +cuda %llvm
+      mpi: cray-mpich@8.1.32 +cuda %llvm ^gdrcopy%gcc
   unify: when_possible
   duplicates:
     strategy: full
@@ -39,7 +39,7 @@ llvm-env:
   - gdrcopy%gcc
   - cuda@12
   - xcb-util-cursor
-  - aws-ofi-nccl
+  - aws-ofi-nccl%gcc
   - superlu%gcc
   variants:
   - +mpi

--- a/recipes/prgenv-llvm/25.11/gh200/environments.yaml
+++ b/recipes/prgenv-llvm/25.11/gh200/environments.yaml
@@ -1,0 +1,51 @@
+llvm-env:
+  compiler: [llvm]
+  network:
+      mpi: cray-mpich@8.1.32 +cuda
+  unify: true
+  specs:
+  - llvm@18
+  - boost +chrono +filesystem +iostreams +mpi +python +regex +serialization +shared +system +timer
+  - cmake
+  - fftw
+  - fmt
+  - gmp
+  - gsl
+  - hdf5+cxx+hl+fortran
+  - kokkos +aggressive_vectorization ~alloc_async cuda_arch=90 +cuda_constexpr +cuda_lambda ~cuda_relocatable_device_code ~cuda_uvm cxxstd=17 +openmp +pic +serial +shared +tuning +wrapper
+  - kokkos-kernels +blas +cublas +cusparse +cusolver +execspace_cuda +execspace_openmp +execspace_serial +lapack +memspace_cudaspace +openmp scalars=float,double,complex_float,complex_double +serial +shared +superlu
+  - kokkos-tools +mpi +papi
+  - netlib-scalapack
+  - lua
+  - libtree
+  - lz4
+  - meson
+  - netcdf-c
+  - netcdf-cxx
+  - netcdf-cxx4
+  - netcdf-fortran
+  - ninja
+  - openblas threads=openmp
+  - osu-micro-benchmarks
+  - papi
+  - python
+  - zlib-ng
+  # add GPU-specific packages here, for easier comparison with mc version
+  - hipsycl
+  - nccl
+  - nccl-tests
+  - cuda
+  - xcb-util-cursor
+  - aws-ofi-nccl
+  - superlu
+  variants:
+  - +mpi
+  - +cuda
+  - cuda_arch=90a
+  views:
+    default:
+      link: roots
+      uenv:
+        add_compilers: true
+        prefix_paths:
+          LD_LIBRARY_PATH: [lib, lib64]

--- a/recipes/prgenv-llvm/25.11/gh200/environments.yaml
+++ b/recipes/prgenv-llvm/25.11/gh200/environments.yaml
@@ -3,6 +3,8 @@ llvm-env:
   network:
       mpi: cray-mpich@8.1.32 +cuda
   unify: true
+  duplicates:
+    strategy: full
   specs:
   - llvm@18
   - boost +chrono +filesystem +iostreams +mpi +python +regex +serialization +shared +system +timer

--- a/recipes/prgenv-llvm/25.11/gh200/environments.yaml
+++ b/recipes/prgenv-llvm/25.11/gh200/environments.yaml
@@ -1,7 +1,7 @@
 llvm-env:
   compiler: [llvm]
   network:
-      mpi: cray-mpich@8.1.32%llvm +cuda
+      mpi: cray-mpich@8.1.32 +cuda %llvm
   unify: when_possible
   duplicates:
     strategy: full

--- a/recipes/prgenv-llvm/25.11/gh200/environments.yaml
+++ b/recipes/prgenv-llvm/25.11/gh200/environments.yaml
@@ -36,7 +36,7 @@ llvm-env:
   - hipsycl
   - nccl
   - nccl-tests
-  - cuda
+  - cuda@12
   - xcb-util-cursor
   - aws-ofi-nccl
   - superlu

--- a/recipes/prgenv-llvm/25.11/gh200/environments.yaml
+++ b/recipes/prgenv-llvm/25.11/gh200/environments.yaml
@@ -8,7 +8,7 @@ llvm-env:
   specs:
   - llvm@18
   - boost +chrono +filesystem +iostreams +mpi +python +regex +serialization +shared +system +timer
-  - cmake
+  - cmake ^doxygen%gcc
   - fftw
   - fmt
   - gmp

--- a/recipes/prgenv-llvm/25.11/gh200/extra/reframe.yaml
+++ b/recipes/prgenv-llvm/25.11/gh200/extra/reframe.yaml
@@ -1,0 +1,19 @@
+default:
+  features:
+    - cuda
+    - mpi
+    - cray-mpich
+    - nccl
+    - nccl-tests
+    - openmp
+    - osu-micro-benchmarks
+    - prgenv
+    - serial
+    - llvm
+    - hipsycl
+    - adaptivecpp
+  cc: mpicc
+  cxx: mpic++
+  ftn: mpifort
+  views:
+    - default

--- a/recipes/prgenv-llvm/25.11/gh200/modules.yaml
+++ b/recipes/prgenv-llvm/25.11/gh200/modules.yaml
@@ -1,0 +1,23 @@
+modules:
+  # Paths to check when creating modules for all module sets
+  prefix_inspections:
+    bin:
+      - PATH
+    lib:
+      - LD_LIBRARY_PATH
+    lib64:
+      - LD_LIBRARY_PATH
+
+  default:
+    arch_folder: false
+    # Where to install modules
+    roots:
+      tcl: /user-environment/modules
+    tcl:
+      all:
+        autoload: none
+      hash_length: 0
+      exclude_implicits: true
+      exclude: []
+      projections:
+        all: '{name}/{version}'


### PR DESCRIPTION
With hipsycl/adaptivecpp. Testing, to be decided separately if we deploy this officially.

Note: I'm trying this with llvm as the compiler for everything. However, we can also consider simply adding hipsycl based on llvm to the regular prgenv-gnu. In theory that should also work, but we shall see how this works out...