### PR TITLE
add starlex config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -58,6 +58,17 @@ clusters:
         variables:
           F7T_URL: "https://api.cscs.ch/cw/firecrest/v2"
     runner: f7t
+  starlex:
+    targets:
+      -
+        uarch: 'gh200'
+        partition: 'normal'
+        variables:
+          F7T_URL: "https://api.tds.cscs.ch/stp/firecrest/v2"
+          F7T_TOKEN_URL: "https://auth-tds.cscs.ch/auth/realms/firecrest-clients/protocol/openid-connect/token"
+          F7T_CLIENT_ID: $F7T_TDS_CLIENT_ID
+          F7T_CLIENT_SECRET: $F7T_TDS_CLIENT_SECRET
+    runner: f7t
   beverin:
     targets:
       -


### PR DESCRIPTION
Add TDS config for starlex. The firecrest secrets are already in https://cicd-ext-mw.cscs.ch/ci/setup/ui?repo=551234120955960 (currently in use on beverin)