### PR TITLE
Pin nccl, aws-ofi-nccl, libcxi, cassini-headers, cxi-driver in pytorch uenv

### DIFF
--- a/recipes/pytorch/v2.9.1/gh200/environments.yaml
+++ b/recipes/pytorch/v2.9.1/gh200/environments.yaml
@@ -25,7 +25,7 @@ pytorch-env:
   - osu-micro-benchmarks
   - papi
   - zlib-ng
-  - nccl
+  - nccl@2.28.7-1
   - nccl-tests
   - cuda
   - cudnn
@@ -34,7 +34,10 @@ pytorch-env:
   - cublasmp
   - nvidia-mathdx
   - xcb-util-cursor
-  - aws-ofi-nccl@1.18.0-dev
+  - aws-ofi-nccl@1.17.3
+  - libcxi@git.release/shs-13.1.0=13.1.0
+  - cxi-driver@git.release/shs-13.1.0=13.1.0
+  - cassini-headers@git.release/shs-13.1.0=13.1.0
   - nvshmem ~ucx +nccl +gdrcopy +libfabric +mpi +python +gpu_initiated_support
   - libunwind@master +pic ~tests components=coredump,ptrace,setjmp +xz +zlib
   - hydra


### PR DESCRIPTION
Not meant for merging, just for testing pinned versions for recent networking issues. Similar to https://github.com/eth-cscs/alps-uenv/pull/326.