### PR TITLE
Update slurm accounts in config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -22,7 +22,7 @@ clusters:
         partition: 'normal'
         variables:
           F7T_URL: 'https://api.cscs.ch/ml/firecrest/v2'
-          SLURM_ACCOUNT: 'a-csstaff'
+          SLURM_ACCOUNT: 'csstaff'
     runner: f7t
   clariden:
     targets:
@@ -31,7 +31,7 @@ clusters:
         partition: 'normal'
         variables:
           F7T_URL: "https://api.cscs.ch/ml/firecrest/v2"
-          SLURM_ACCOUNT: 'a-csstaff'
+          SLURM_ACCOUNT: 'csstaff'
     runner: f7t
   daint:
     targets:
@@ -40,6 +40,7 @@ clusters:
         partition: 'normal'
         variables:
           F7T_URL: "https://api.cscs.ch/hpc/firecrest/v2"
+          SLURM_ACCOUNT: 'csstaff'
     runner: f7t
   eiger:
     targets:
@@ -49,6 +50,7 @@ clusters:
         variables:
           SLURM_CONSTRAINT: 'mc'
           F7T_URL: "https://api.cscs.ch/hpc/firecrest/v2"
+          SLURM_ACCOUNT: 'csstaff'
     runner: f7t
   santis:
     targets:
@@ -57,6 +59,7 @@ clusters:
         partition: 'normal'
         variables:
           F7T_URL: "https://api.cscs.ch/cw/firecrest/v2"
+          SLURM_ACCOUNT: 'csstaff'
     runner: f7t
   starlex:
     targets:
@@ -68,6 +71,7 @@ clusters:
           F7T_TOKEN_URL: "https://auth-tds.cscs.ch/auth/realms/firecrest-clients/protocol/openid-connect/token"
           F7T_CLIENT_ID: $F7T_TDS_CLIENT_ID
           F7T_CLIENT_SECRET: $F7T_TDS_CLIENT_SECRET
+          SLURM_ACCOUNT: 'csstaff-1'
     runner: f7t
   beverin:
     targets:


### PR DESCRIPTION
Some clusters now require an account, some can now use `csstaff` instead of `a-csstaff`. starlex for some reason requires `csstaff-1`. May change in the future, but for now it's required. See https://cscs-lugano.slack.com/archives/C011JEWKEFQ/p1774535658401539?thread_ts=1774533918.667049&cid=C011JEWKEFQ for discussion.