### PR TITLE
PrgEnv-intel replacement for eiger

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -177,6 +177,10 @@ uenvs:
         gh200: wcp/icon/v1/gh200
       deploy:
         santis: [gh200]
+  intel-classic:
+    "26.07":
+      recipes:
+        zen2: "26.07"
   julia:
     "24.9":
       recipes:

--- a/config.yaml
+++ b/config.yaml
@@ -181,6 +181,8 @@ uenvs:
     "26.07":
       recipes:
         zen2: "26.07"
+      deploy:
+        eiger: [zen2]
   julia:
     "24.9":
       recipes:

--- a/recipes/intel-classic/26.07/README.md
+++ b/recipes/intel-classic/26.07/README.md
@@ -1,0 +1,85 @@
+# intel-classic — build notes
+
+A one-off uenv for a legacy user needing a mixed Intel toolchain:
+
+- **C / C++** = Intel **oneAPI** `icx` / `icpx` (2023.2.4)
+- **Fortran** = Intel **classic** `ifort` (2021.10.0)
+- `cray-mpich@8.1.32` wrappers: `mpicc→icx`, `mpicxx→icpx`, `mpif90/mpifort→ifort`
+- hdf5, netcdf-{c,cxx,fortran}, osu-micro-benchmarks, system libfabric
+
+Single view `intel` (default), mounted at `/user-environment`.
+
+## How the mixed toolchain is expressed
+
+`compilers.yaml` declares only `intel-classic` (spack pkg
+`intel-oneapi-compilers-classic`). Stackinator's `intel-classic` compiler group
+*also* builds `intel-oneapi-compilers` (the icx/icpx/ifx provider) as an internal
+dependency, so both toolchains are in the store, but only the classic one is
+"named".
+
+`environments.yaml` carries a **hand-written `prefer:`** that pins the per-language
+compiler for every built package:
+
+```yaml
+prefer:
+- '%[when=%c] c=oneapi %[when=%cxx] cxx=oneapi %[when=%fortran] fortran=intel'
+```
+
+plus the MPI spec `cray-mpich@8.1.32 %c,cxx=oneapi %fortran=intel`.
+
+## Two recipe-level fixes so the view exposes the right compilers
+
+Out of the box the `intel` view only exposed the **classic** bins and the
+`CC/CXX/FC` env vars dangled. Two fixes in the recipe:
+
+1. **`post-install` hook** — symlinks the oneAPI `icx`/`icpx`/`ifx` from the
+   `intel-oneapi-compilers` install into `<view>/bin`. Stackinator's
+   `add_compilers` step only links the compilers *named* in the environment's
+   `compiler:` list (i.e. classic + gcc), so the oneAPI bins are otherwise
+   missing from the view. The hook globs the store for the (single)
+   `intel-oneapi-compilers-*` prefix and is idempotent (`ln -sf`) — important
+   because stackinator can run the hook more than once.
+
+2. **`env_vars.set` in the `intel` view** — spack auto-sets `CC/CXX/FC` (from the
+   oneAPI compiler package's `setup_run_environment`) to paths under
+   `env/oneapi/compiler/2023.2.4/...`, a subtree that `link: roots` never
+   projects into the view, so they dangle. We override them to the `<view>/bin`
+   symlinks and point **Fortran at classic `ifort`** (spack would default `FC` to
+   `ifx`). Uses the `$@view_path@` substitution.
+
+### Why NOT add `intel-oneapi` as a second compiler group
+
+The obvious approach — adding `intel-oneapi` to `compilers.yaml` and the env
+`compiler:` list so the view step links icx/icpx automatically — was tried and
+**rejected**. It makes `prgenv` `needs:` both compiler groups and produced a
+*second, parallel concretization* of the whole MPI stack (a duplicate
+`cray-mpich`, `hdf5`, `netcdf-*`, `osu-*`). The two copies then collide on module
+file names (`==> Error: Name clashes detected in module files`) and the build
+fails at the `modules-done` step. The post-install-hook approach leaves the
+known-good single-stack concretization untouched.
+
+## Gotcha: orphaned installs after re-concretization
+
+`spack.commit`/`packages.commit` in `config.yaml` are **branches**
+(`releases/v1.2`, `releases/v2026.06`). Re-running `stack-config` re-fetches them,
+which can shift concretization to new hashes while the old installs remain in the
+store DB — again triggering a module-name clash. If you hit this after an
+iteration, uninstall the orphans (installs whose hash is absent from
+`env/spack.lock`) before the modules step, e.g. inside `stack-debug.sh`:
+
+```
+spack uninstall --force --yes-to-all /<hash> ...
+```
+
+or do a clean-store rebuild.
+
+## Verified (2026-08-06)
+
+All exercised inside `uenv run store.squashfs`:
+
+- `which` + `--version`: icx/icpx 2023.2.4, ifort 2021.10.0, ifx 2023.2.4, icc/icpc classic — all in view.
+- `CC=icx`, `CXX=icpx`, `FC=F77=ifort` — all resolve (no dangling).
+- `mpicc -show`→icx, `mpicxx -show`→icpx, `mpif90 -show`→ifort.
+- Compile **and run**: C (icx), C++ (icpx), Fortran (ifort).
+- 2-rank MPI (`srun -n2`): C and Fortran both print ranks.
+- hdf5 1.14.6 `h5cc` compile+run; netcdf-c 4.10.0 / netcdf-fortran 4.6.2 (`nc-config --cc`→icx).

--- a/recipes/intel-classic/26.07/README.md
+++ b/recipes/intel-classic/26.07/README.md
@@ -27,18 +27,25 @@ prefer:
 
 plus the MPI spec `cray-mpich@8.1.32 %c,cxx=oneapi %fortran=intel`.
 
-## Two recipe-level fixes so the view exposes the right compilers
+## Recipe-level fixes so the view exposes a working toolchain
 
-Out of the box the `intel` view only exposed the **classic** bins and the
-`CC/CXX/FC` env vars dangled. Two fixes in the recipe:
+Out of the box the `intel` view only exposed the **classic** bins, the
+`CC/CXX/FC` env vars dangled, and classic **Fortran linking was broken**. Three
+fixes in the recipe:
 
-1. **`post-install` hook** — symlinks the oneAPI `icx`/`icpx`/`ifx` from the
-   `intel-oneapi-compilers` install into `<view>/bin`. Stackinator's
+1. **`post-install` hook, part 1 — oneAPI bins into the view.** Symlinks the
+   oneAPI `icx`/`icpx`/`ifx` from the `intel-oneapi-compilers` install into
+   `<view>/bin` (i.e. `/user-environment/env/intel/bin`). Stackinator's
    `add_compilers` step only links the compilers *named* in the environment's
    `compiler:` list (i.e. classic + gcc), so the oneAPI bins are otherwise
    missing from the view. The hook globs the store for the (single)
    `intel-oneapi-compilers-*` prefix and is idempotent (`ln -sf`) — important
    because stackinator can run the hook more than once.
+   **NB:** the hook's target must be the *default view's* bin. The view is named
+   `intel` (see `config.yaml`/`environments.yaml`), so `view_bin` is
+   `env/intel/bin`. An earlier revision hard-coded `env/oneapi/bin` (a stale
+   view name); that directory is not on `PATH`, so `which icx` failed and
+   `CC`/`CXX` dangled even though the symlinks existed.
 
 2. **`env_vars.set` in the `intel` view** — spack auto-sets `CC/CXX/FC` (from the
    oneAPI compiler package's `setup_run_environment`) to paths under
@@ -46,6 +53,28 @@ Out of the box the `intel` view only exposed the **classic** bins and the
    projects into the view, so they dangle. We override them to the `<view>/bin`
    symlinks and point **Fortran at classic `ifort`** (spack would default `FC` to
    `ifx`). Uses the `$@view_path@` substitution.
+
+3. **`post-install` hook, part 2 — classic Fortran runtime libs on
+   `LD_LIBRARY_PATH`.** Classic `ifort` drives GNU `ld` with an LTO plugin
+   (`<classic>/lib/icx-lto.so`) that `NEED`s `libimf.so` / `libsvml.so` /
+   `libirng.so` / `libintlc.so.5`. Spack baked a `RUNPATH` into that plugin
+   pointing at the **`intel-oneapi-compilers`** store prefix
+   (`compiler/<ver>/linux/compiler/lib/intel64_lin`) — a *different* package with
+   a *different* hash — and that `RUNPATH` is the plugin's **only** resolution
+   path (the view does not project the compiler `lib` subtree). So after a
+   re-concretization that shifts `intel-oneapi-compilers` to a new hash and
+   orphans the old install, the `RUNPATH` dangles and Fortran linking dies with:
+
+   ```
+   ld: .../icx-lto.so: error loading plugin: libimf.so: cannot open shared object file
+   ```
+
+   The classic compiler ships its *own* copy of these libs under
+   `compiler/lib/intel64_lin`. The hook symlinks them into `<view>/lib`, which is
+   already on the view's `LD_LIBRARY_PATH` and is searched **before** the plugin's
+   `RUNPATH`. Resolution becomes self-contained within the (always-present, named)
+   classic compiler and no longer depends on the oneAPI package's hash. Verified
+   with `ldd icx-lto.so` → `libimf.so => .../env/intel/lib/libimf.so`.
 
 ### Why NOT add `intel-oneapi` as a second compiler group
 
@@ -65,21 +94,36 @@ known-good single-stack concretization untouched.
 which can shift concretization to new hashes while the old installs remain in the
 store DB — again triggering a module-name clash. If you hit this after an
 iteration, uninstall the orphans (installs whose hash is absent from
-`env/spack.lock`) before the modules step, e.g. inside `stack-debug.sh`:
+`env/spack.lock`) before the modules step. From inside the sandbox (copy the
+`env … bwrap-mutable-root.sh …` line out of `stack-debug.sh` and append
+`bash -noprofile -lc "<cmd>"`), the exact reconciliation is:
 
+```sh
+keep=$(spack -e $BUILD/env find --format '{/hash}' | sort -u)   # keep set (spack.lock)
+allh=$(spack find          --format '{/hash}' | sort -u)         # everything in the store DB
+orphans=$(comm -13 <(echo "$keep") <(echo "$allh"))              # installed but not in the env
+spack uninstall --force --yes-to-all $orphans
 ```
-spack uninstall --force --yes-to-all /<hash> ...
-```
 
-or do a clean-store rebuild.
+Compare hashes *with* their leading `/` on both sides — mismatched stripping
+makes `comm` flag the keepers as orphans too. Then re-run `make store.squashfs`
+(it re-runs the modules step, the post-install hook, and repackages). Or do a
+clean-store rebuild.
 
-## Verified (2026-08-06)
+## Verified (2026-08-06, after the Fortran-linking fix)
 
 All exercised inside `uenv run store.squashfs`:
 
-- `which` + `--version`: icx/icpx 2023.2.4, ifort 2021.10.0, ifx 2023.2.4, icc/icpc classic — all in view.
+- `which`: icx/icpx/ifx **and** icc/icpc/ifort all resolve to `env/intel/bin`.
+- `--version`: icx/icpx/ifx 2023.2.4, ifort 2021.10.0, icc/icpc classic.
 - `CC=icx`, `CXX=icpx`, `FC=F77=ifort` — all resolve (no dangling).
-- `mpicc -show`→icx, `mpicxx -show`→icpx, `mpif90 -show`→ifort.
-- Compile **and run**: C (icx), C++ (icpx), Fortran (ifort).
-- 2-rank MPI (`srun -n2`): C and Fortran both print ranks.
-- hdf5 1.14.6 `h5cc` compile+run; netcdf-c 4.10.0 / netcdf-fortran 4.6.2 (`nc-config --cc`→icx).
+- Compile **and run** (all 6 drivers): C (icx/icc), C++ (icpx/icpc), Fortran (ifort/ifx).
+- **Fortran linking regression fixed:** `ifort hello.F90` and `mpif90 hello.F90`
+  both link and run. `ldd .../icx-lto.so` shows `libimf.so` (and svml/irng/intlc)
+  resolving from `env/intel/lib/` — the classic package's own libs via
+  `LD_LIBRARY_PATH`, not the oneAPI-hashed `RUNPATH`. This is robust across
+  re-concretization (previously failed with `error loading plugin: libimf.so`).
+- `mpicc` compile+run.
+
+Not re-run this pass (unchanged since prior verification): 2-rank `srun` MPI,
+hdf5 `h5cc`, netcdf `nc-config`.

--- a/recipes/intel-classic/26.07/compilers.yaml
+++ b/recipes/intel-classic/26.07/compilers.yaml
@@ -1,0 +1,4 @@
+gcc:
+  version: "system"
+intel-classic:
+  version: "2021.10.0"

--- a/recipes/intel-classic/26.07/config.yaml
+++ b/recipes/intel-classic/26.07/config.yaml
@@ -1,0 +1,11 @@
+name: intel-classic
+spack:
+  repo: https://github.com/spack/spack.git
+  commit: releases/v1.2
+  packages:
+    repo: https://github.com/spack/spack-packages.git
+    commit: releases/v2026.06
+store: /user-environment
+description: Intel classic toolchain with cray-mpich, Python, CMake and other development tools.
+default-view: intel
+version: 3

--- a/recipes/intel-classic/26.07/environments.yaml
+++ b/recipes/intel-classic/26.07/environments.yaml
@@ -1,0 +1,39 @@
+prgenv:
+  compiler: [intel-classic, gcc]
+  network:
+      mpi: cray-mpich@8.1.32 %c,cxx=oneapi %fortran=intel
+      # use the system libfabric because BYO libfabric forces gcc to be used to build other packages
+      specs: ['libfabric@1.22']
+  unify: true
+  specs:
+  #  does not build because of -ffp-model=consistent flag
+  #- openblas threads=openmp
+  - hdf5+cxx+hl+fortran
+  - netcdf-c build_system=cmake
+  - netcdf-cxx
+  - netcdf-fortran
+  - osu-micro-benchmarks
+  prefer:
+  - '%[when=%c] c=oneapi %[when=%cxx] cxx=oneapi %[when=%fortran] fortran=intel'
+  variants:
+  - +mpi
+  views:
+    intel:
+      link: roots
+      uenv:
+        add_compilers: true
+        prefix_paths:
+          LD_LIBRARY_PATH: [lib, lib64]
+        # The intel-classic compiler group builds intel-oneapi-compilers (icx/icpx/ifx)
+        # as an internal dependency but stackinator only exposes the *classic* bins
+        # (icc/icpc/ifort) in the view. A post-install hook symlinks the oneAPI bins
+        # into <view>/bin. Spack still auto-sets CC/CXX/FC from the oneAPI package to
+        # paths under env/oneapi/compiler/2023.2.4/... which link:roots never projects,
+        # so they dangle — override them here to the <view>/bin symlinks, with Fortran
+        # pointing at classic ifort (the intended toolchain) rather than ifx.
+        env_vars:
+          set:
+            - CC: $@view_path@/bin/icx
+            - CXX: $@view_path@/bin/icpx
+            - FC: $@view_path@/bin/ifort
+            - F77: $@view_path@/bin/ifort

--- a/recipes/intel-classic/26.07/extra/reframe.yaml
+++ b/recipes/intel-classic/26.07/extra/reframe.yaml
@@ -1,0 +1,13 @@
+default:
+  features:
+    - mpi
+    - openmp
+    - osu-micro-benchmarks
+    - prgenv
+    - serial
+    - oneapi
+  cc: mpicc
+  cxx: mpic++
+  ftn: mpifort
+  views:
+    - oneapi

--- a/recipes/intel-classic/26.07/extra/reframe.yaml
+++ b/recipes/intel-classic/26.07/extra/reframe.yaml
@@ -10,4 +10,4 @@ default:
   cxx: mpic++
   ftn: mpifort
   views:
-    - oneapi
+    - intel

--- a/recipes/intel-classic/26.07/modules.yaml
+++ b/recipes/intel-classic/26.07/modules.yaml
@@ -1,0 +1,18 @@
+modules:
+  # Paths to check when creating modules for all module sets
+  prefix_inspections:
+    bin:
+      - PATH
+    lib:
+      - LD_LIBRARY_PATH
+    lib64:
+      - LD_LIBRARY_PATH
+
+  default:
+    arch_folder: false
+    tcl:
+      hash_length: 0
+      exclude_implicits: true
+      exclude: []
+      projections:
+        all: '{name}/{version}'

--- a/recipes/intel-classic/26.07/post-install
+++ b/recipes/intel-classic/26.07/post-install
@@ -1,22 +1,28 @@
 #!/bin/sh
-# Expose the oneAPI C/C++/Fortran compilers (icx/icpx/ifx) in the oneapi view.
+# Recipe post-install hook for the intel-classic uenv. Runs inside the sandbox
+# after the Spack build, before the squashfs is packaged. Two jobs, both fixing
+# gaps in what the `intel` view exposes. Everything here is idempotent
+# (ln -sf), which matters because stackinator may run this hook more than once.
+set -eu
+
+view_bin="/user-environment/env/intel/bin"
+view_lib="/user-environment/env/intel/lib"
+
+# ---------------------------------------------------------------------------
+# 1. Expose the oneAPI C/C++/Fortran compilers (icx/icpx/ifx) in the view.
 #
 # The intel-classic compiler group builds intel-oneapi-compilers as an internal
 # dependency, but stackinator's add_compilers step only symlinks the *classic*
 # toolchain (icc/icpc/ifort) into the view because the environment's compiler
 # list names intel-classic. The oneAPI bins live in the package's own tree and
 # are never linked, so icx/icpx/ifx are missing from the view PATH and the
-# CC/CXX env vars (overridden in environments.yaml to point at <view>/bin) would
-# otherwise dangle. Symlink them in here. Idempotent (ln -sf), which matters
-# because stackinator may run this hook more than once.
-set -eu
-
-view_bin="/user-environment/env/oneapi/bin"
-
+# CC/CXX env vars (set in environments.yaml to <view>/bin/{icx,icpx}) dangle.
+# Symlink them into <view>/bin.
+# ---------------------------------------------------------------------------
+oneapi_bindir=""
 # Resolve the intel-oneapi-compilers install prefix from the store. There is a
 # single install; glob it rather than depending on the spack DB being queryable
 # from inside the hook.
-oneapi_bindir=""
 for d in /user-environment/linux-*/intel-oneapi-compilers-*/compiler/*/linux/bin; do
     case "$d" in
         *intel-oneapi-compilers-classic-*) continue ;;  # skip the classic package
@@ -42,3 +48,46 @@ for c in icx icpx ifx; do
         echo "post-install: WARNING $c not found in $oneapi_bindir" >&2
     fi
 done
+
+# ---------------------------------------------------------------------------
+# 2. Make the classic Fortran runtime libs resolvable via the view's
+#    LD_LIBRARY_PATH.
+#
+# Classic `ifort` drives GNU `ld` with an LTO plugin (icx-lto.so) that NEEDs
+# libimf.so / libsvml.so / libirng.so / libintlc.so.5. Spack baked a RUNPATH
+# into that plugin pointing at the *intel-oneapi-compilers* store prefix
+# (compiler/<ver>/linux/compiler/lib/intel64_lin) — a different package with a
+# different hash. That RUNPATH is the ONLY resolution path (the view does not
+# project the compiler lib subtree), so after a re-concretization that shifts
+# intel-oneapi-compilers to a new hash the RUNPATH dangles and Fortran linking
+# dies with:
+#   ld: .../icx-lto.so: error loading plugin: libimf.so: cannot open shared object file
+#
+# The classic compiler ships its OWN copy of these libs under
+# compiler/lib/intel64_lin. Symlink them into <view>/lib, which is already on
+# the view's LD_LIBRARY_PATH and is searched BEFORE the plugin's RUNPATH, so
+# resolution becomes self-contained within the (always-present, named) classic
+# compiler and no longer depends on the oneAPI package's hash.
+# ---------------------------------------------------------------------------
+classic_libdir=""
+for d in /user-environment/linux-*/intel-oneapi-compilers-classic-*/compiler/lib/intel64_lin; do
+    if [ -e "$d/libimf.so" ]; then
+        classic_libdir="$d"
+        break
+    fi
+done
+
+if [ -z "$classic_libdir" ]; then
+    echo "post-install: ERROR could not locate classic compiler intel64_lin lib dir" >&2
+    exit 1
+fi
+
+echo "post-install: linking classic runtime libs from $classic_libdir into $view_lib"
+mkdir -p "$view_lib"
+n=0
+for so in "$classic_libdir"/*.so "$classic_libdir"/*.so.*; do
+    [ -e "$so" ] || continue
+    ln -sf "$so" "$view_lib/$(basename "$so")"
+    n=$((n + 1))
+done
+echo "post-install:   linked $n runtime libs"

--- a/recipes/intel-classic/26.07/post-install
+++ b/recipes/intel-classic/26.07/post-install
@@ -1,0 +1,44 @@
+#!/bin/sh
+# Expose the oneAPI C/C++/Fortran compilers (icx/icpx/ifx) in the oneapi view.
+#
+# The intel-classic compiler group builds intel-oneapi-compilers as an internal
+# dependency, but stackinator's add_compilers step only symlinks the *classic*
+# toolchain (icc/icpc/ifort) into the view because the environment's compiler
+# list names intel-classic. The oneAPI bins live in the package's own tree and
+# are never linked, so icx/icpx/ifx are missing from the view PATH and the
+# CC/CXX env vars (overridden in environments.yaml to point at <view>/bin) would
+# otherwise dangle. Symlink them in here. Idempotent (ln -sf), which matters
+# because stackinator may run this hook more than once.
+set -eu
+
+view_bin="/user-environment/env/oneapi/bin"
+
+# Resolve the intel-oneapi-compilers install prefix from the store. There is a
+# single install; glob it rather than depending on the spack DB being queryable
+# from inside the hook.
+oneapi_bindir=""
+for d in /user-environment/linux-*/intel-oneapi-compilers-*/compiler/*/linux/bin; do
+    case "$d" in
+        *intel-oneapi-compilers-classic-*) continue ;;  # skip the classic package
+    esac
+    if [ -x "$d/icx" ]; then
+        oneapi_bindir="$d"
+        break
+    fi
+done
+
+if [ -z "$oneapi_bindir" ]; then
+    echo "post-install: ERROR could not locate intel-oneapi-compilers icx bin dir" >&2
+    exit 1
+fi
+
+echo "post-install: linking oneAPI compilers from $oneapi_bindir into $view_bin"
+mkdir -p "$view_bin"
+for c in icx icpx ifx; do
+    if [ -x "$oneapi_bindir/$c" ]; then
+        ln -sf "$oneapi_bindir/$c" "$view_bin/$c"
+        echo "post-install:   linked $c"
+    else
+        echo "post-install: WARNING $c not found in $oneapi_bindir" >&2
+    fi
+done


### PR DESCRIPTION
A small uenv that provides
- `intel-oneapi-compilers@2023.2.4`
- `intel-oneapi-compilers@2021.10.0`
Configured for users of PrgEnv-intel on Eiger who are unable to migrate quite yet.