### PR TITLE
update esmf for new eiger image

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -115,6 +115,13 @@ uenvs:
       deploy:
         eiger: [zen2]
       mount: "/user-tools"
+  esmf:
+    "26.07":
+      recipes:
+        zen2: "26.07"
+      deploy:
+        eiger: [zen2]
+      mount: "/user-environment"
   gromacs:
     "2023":
       recipes:

--- a/recipes/esmf/26.07/README.md
+++ b/recipes/esmf/26.07/README.md
@@ -1,0 +1,61 @@
+# esmf uenv — build notes
+
+Recipe format **v3** (Stackinator 7), Spack `releases/v1.2` + spack-packages
+`releases/v2026.06`, **system gcc-14** (external, from cluster config). Two
+environments/views: `esmf` (MPI, cray-mpich@8.1.32) and `esmf-serial` (no MPI).
+
+## The openssl / srun breakage (why views use `link: roots`)
+
+Symptom on the new pilatus/eiger OS image:
+
+```
+uenv run esmf/26.2:v1@eiger --view=esmf -- srun --version
+srun: error: dlopen(/usr/lib64/slurm/cli_filter_SitePolicies.so):
+  /usr/lib64/libcrypto.so.3: version `OPENSSL_3.3.0' not found
+  (required by /user-environment/.../openssl-3.6.0/lib64/libssl.so.3)
+```
+
+Root cause: the old recipe used `link: run` on the views, which pulls **every**
+run dependency of the roots into the view — including `openssl` (a transitive
+dep of curl/python/subversion). Combined with `prefix_paths: LD_LIBRARY_PATH:
+[lib, lib64]`, the uenv's `libssl.so.3` (3.6.0) leaked onto a **global**
+`LD_LIBRARY_PATH`. When the **system** `srun` dlopen'd a **system** Slurm plugin,
+the loader bound the uenv's libssl 3.6.0 but the plugin dragged in the **system**
+libcrypto.so.3 (older) → `OPENSSL_3.3.0` symbol mismatch → dlopen fails.
+
+Fix: views use **`link: roots`** so only explicitly-requested specs land in the
+view / on `LD_LIBRARY_PATH`. openssl, curl, etc. stay in the store, reached only
+via RPATH by the binaries that actually need them. Verified: no
+`libssl`/`libcrypto`/`libcurl` in either view, and `srun --version` works.
+
+## Packages that MUST be explicit roots because of `link: roots`
+
+`link: roots` only links the listed specs into the view. Files resolved by
+**path/@INC** (not RPATH) are therefore missing unless the providing package is
+itself a root. Found while building CESM `cesm3_0_beta07`:
+
+- **`perl-xml-sax-base`** — provides `XML::SAX::Exception`, `XML::SAX::Base`.
+- **`perl-xml-namespacesupport`** — provides `XML::NamespaceSupport`.
+
+Both are run deps of `perl-xml-sax` (a root), but Perl finds modules via `@INC`
+(the view path), not RPATH — so CESM's CLM `build-namelist` (which loads
+`XML::LibXML` → `XML::SAX`) failed with `Can't locate XML/SAX/Exception.pm`
+until these were added as roots. Anything similar (perl/python modules, data
+files under `share/`) that a tool loads by path must be an explicit root.
+
+Libraries (netcdf, hdf5, esmf, parallelio, pnetcdf, openblas, fftw, gsl,
+cray-mpich, libfabric) work fine as roots + RPATH and needed no extra additions.
+
+## Validation performed (pilatus)
+
+- `srun --version` → `slurm 25.05.4` in both views (reproducer fixed).
+- Full CESM build: clone `cesm3_0_beta07`, `git-fleximod update`,
+  `create_newcase --machine eiger --compset FHIST --res f09_g17 --compiler gnu`,
+  `case.setup`, `case.build` → **MODEL BUILD HAS FINISHED SUCCESSFULLY**
+  (`cesm.exe` links cleanly; its libssl/libcrypto resolve to the consistent
+  system pair, no uenv leak).
+
+## Machine files (`extra/<view>/machines/eiger/`)
+
+`config_machines.xml` `mpirun` args hardcode the uenv tag — bumped to
+`--uenv=esmf/26.07:v1` for this release. Update on each version bump.

--- a/recipes/esmf/26.07/compilers.yaml
+++ b/recipes/esmf/26.07/compilers.yaml
@@ -1,0 +1,2 @@
+gcc:
+  version: "system"

--- a/recipes/esmf/26.07/config.yaml
+++ b/recipes/esmf/26.07/config.yaml
@@ -1,0 +1,10 @@
+name: esmf
+spack:
+  repo: https://github.com/spack/spack.git
+  commit: releases/v1.2
+  packages:
+    repo: https://github.com/spack/spack-packages.git
+    commit: releases/v2026.06
+store: /user-environment
+description: GNU Compiler toolchain with ESMF for CESM on multicore
+version: 3

--- a/recipes/esmf/26.07/environments.yaml
+++ b/recipes/esmf/26.07/environments.yaml
@@ -1,0 +1,99 @@
+esmf-env:
+  compiler: [gcc]
+  network:
+      mpi: cray-mpich@8.1.32
+  unify: true
+  specs:
+  - cmake
+  - fftw
+  - gsl
+  - hdf5+cxx+hl+fortran
+  - lua
+  - libtree
+  - lz4
+  - netcdf-c build_system=cmake
+  - netcdf-cxx
+  - netcdf-fortran
+  - parallel-netcdf
+  - openblas threads=openmp
+  - osu-micro-benchmarks
+  - python
+  - gmake
+  - zlib-ng
+  - libxml2
+  # NCAR packages
+  - parallelio@2.6.6 +fortran +ncint +pnetcdf
+  - esmf@8.8.0 +pnetcdf
+  # needed when bootstrapping CESM
+  - subversion
+  # perl is used directly by CESM
+  - perl
+  - perl-xml-libxml
+  - perl-xml-namespacesupport
+  - perl-xml-sax
+  - perl-xml-sax-base
+  # the python code uses lxml
+  - py-lxml
+  variants:
+  - +mpi
+  views:
+    esmf:
+      link: roots
+      uenv:
+        add_compilers: true
+        prefix_paths:
+          LD_LIBRARY_PATH: [lib, lib64]
+        env_vars:
+            set:
+            - ESMF_LIBDIR: '$@view_path@/lib'
+            - PNETCDF_PATH: '$@view_path@'
+            - NETCDF_PATH: '$@view_path@'
+            - MACHINE_PATH: '$@mount@/meta/extra/$@view_name@/machines/eiger'
+esmf-serial:
+  compiler: [gcc]
+  network: # no MPI
+      mpi: null
+  unify: true
+  specs:
+  - cmake
+  - fftw ~mpi
+  - gsl
+  - hdf5+cxx+hl+fortran
+  - lua
+  - libtree
+  - lz4
+  - netcdf-c build_system=cmake ~mpi
+  - netcdf-cxx
+  - netcdf-fortran
+  - openblas threads=openmp
+  - python
+  - gmake
+  - zlib-ng
+  - libxml2
+  # NCAR packages
+  - parallelio@2.6.6 +fortran +ncint ~mpi
+  - esmf@8.8.0 ~pnetcdf
+  # needed when bootstrapping CESM
+  - subversion
+  # perl is used directly by CESM
+  - perl
+  - perl-xml-libxml
+  - perl-xml-namespacesupport
+  - perl-xml-sax
+  - perl-xml-sax-base
+  # the python code uses lxml
+  - py-lxml
+  variants:
+  - ~mpi
+  views:
+    esmf-serial:
+      link: roots
+      uenv:
+        add_compilers: true
+        prefix_paths:
+          LD_LIBRARY_PATH: [lib, lib64]
+        env_vars:
+            set:
+            - ESMF_LIBDIR: '$@view_path@/lib'
+            - NETCDF_PATH: '$@view_path@'
+            - MACHINE_PATH: '$@mount@/meta/extra/$@view_name@/machines/eiger'

--- a/recipes/esmf/26.07/extra/esmf-serial/machines/eiger/config_batch.xml
+++ b/recipes/esmf/26.07/extra/esmf-serial/machines/eiger/config_batch.xml
@@ -1,0 +1,11 @@
+  <batch_system MACH="eiger" type="slurm" >
+    <batch_submit>sbatch</batch_submit>
+    <submit_args>
+      <argument> --time $JOB_WALLCLOCK_TIME </argument>
+      <argument> --partition $JOB_PARTITION </argument>
+      <argument> --account $JOB_ACCOUNT </argument>
+    </submit_args>
+    <queues>
+      <queue default="true">default</queue>
+    </queues>
+  </batch_system>

--- a/recipes/esmf/26.07/extra/esmf-serial/machines/eiger/config_machines.xml
+++ b/recipes/esmf/26.07/extra/esmf-serial/machines/eiger/config_machines.xml
@@ -1,0 +1,38 @@
+  <machine MACH="eiger">
+    <DESC>CSCS AMD EPYC 7742 CPU Rome system</DESC>
+    <OS>LINUX</OS>
+    <COMPILERS>gnu</COMPILERS>
+    <MPILIBS>mpich</MPILIBS>
+    <CIME_OUTPUT_ROOT>$ENV{SCRATCH}/ctsm5_3/output</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>TODO</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>TODO</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>$ENV{SCRATCH}/ctsm5_3/archive/$CASE</DOUT_S_ROOT>
+    <BASELINE_ROOT>$ENV{CESMDATAROOT}/cesm_baselines</BASELINE_ROOT>
+    <CCSM_CPRNC>$ENV{SCRATCH}/ctsm5_3/cprnc/cprnc</CCSM_CPRNC>
+    <GMAKE_J>12</GMAKE_J>
+    <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
+    <SUPPORTED_BY>bcumming@cscs.ch</SUPPORTED_BY>
+    <MAX_TASKS_PER_NODE>128</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>128</MAX_MPITASKS_PER_NODE>
+    <mpirun mpilib="default">
+     <executable>srun</executable>
+      <arguments>
+        <arg name="cpubind"> --cpu_bind=rank</arg>
+        <arg name="uenv"> --uenv=esmf/26.07:v1</arg>
+        <arg name="view"> --view=esmf-serial</arg>
+        <arg name="uenvpassthrough"> --uenv-passthrough=use</arg>
+      </arguments>
+    </mpirun>
+
+    <module_system type="none"/>
+
+    <environment_variables>
+      <env name="OMP_STACKSIZE">128M</env>
+      <env name="FI_CXI_RX_MATCH_MODE">hybrid</env>
+    </environment_variables>
+    <environment_variables comp_interface="nuopc">
+      <!-- required on all systems for timing file output --> 
+      <env name="ESMF_RUNTIME_PROFILE">ON</env>
+      <env name="ESMF_RUNTIME_PROFILE_OUTPUT">SUMMARY</env>
+    </environment_variables>
+  </machine>

--- a/recipes/esmf/26.07/extra/esmf-serial/machines/eiger/gnu_eiger.cmake
+++ b/recipes/esmf/26.07/extra/esmf-serial/machines/eiger/gnu_eiger.cmake
@@ -1,0 +1,9 @@
+# work around strict compiler warnings in gfortran 10 and later
+string(APPEND FFLAGS " -fallow-argument-mismatch -fallow-invalid-boz")
+if (compile_threaded)
+  string(APPEND FFLAGS " -qopenmp")
+endif()
+
+# help CESM find lapack
+string(APPEND SLIBS " -L/user-environment/env/esmf/lib -lopenblas")
+

--- a/recipes/esmf/26.07/extra/esmf/machines/eiger/config_batch.xml
+++ b/recipes/esmf/26.07/extra/esmf/machines/eiger/config_batch.xml
@@ -1,0 +1,11 @@
+  <batch_system MACH="eiger" type="slurm" >
+    <batch_submit>sbatch</batch_submit>
+    <submit_args>
+      <argument> --time $JOB_WALLCLOCK_TIME </argument>
+      <argument> --partition $JOB_PARTITION </argument>
+      <argument> --account $JOB_ACCOUNT </argument>
+    </submit_args>
+    <queues>
+      <queue default="true">default</queue>
+    </queues>
+  </batch_system>

--- a/recipes/esmf/26.07/extra/esmf/machines/eiger/config_machines.xml
+++ b/recipes/esmf/26.07/extra/esmf/machines/eiger/config_machines.xml
@@ -1,0 +1,38 @@
+  <machine MACH="eiger">
+    <DESC>CSCS AMD EPYC 7742 CPU Rome system</DESC>
+    <OS>LINUX</OS>
+    <COMPILERS>gnu</COMPILERS>
+    <MPILIBS>mpich</MPILIBS>
+    <CIME_OUTPUT_ROOT>$ENV{SCRATCH}/ctsm5_3/output</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>/capstor/store/cscs/uzh/uzh47/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/capstor/store/cscs/uzh/uzh47/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>$ENV{SCRATCH}/ctsm5_3/archive/$CASE</DOUT_S_ROOT>
+    <BASELINE_ROOT>$ENV{CESMDATAROOT}/cesm_baselines</BASELINE_ROOT>
+    <CCSM_CPRNC>$ENV{SCRATCH}/ctsm5_3/cprnc/cprnc</CCSM_CPRNC>
+    <GMAKE_J>12</GMAKE_J>
+    <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
+    <SUPPORTED_BY>bcumming@cscs.ch</SUPPORTED_BY>
+    <MAX_TASKS_PER_NODE>128</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>128</MAX_MPITASKS_PER_NODE>
+    <mpirun mpilib="default">
+     <executable>srun</executable>
+      <arguments>
+        <arg name="cpubind"> --cpu_bind=rank</arg>
+        <arg name="uenv"> --uenv=esmf/26.07:v1</arg>
+        <arg name="view"> --view=esmf</arg>
+        <arg name="uenvpassthrough"> --uenv-passthrough=use</arg>
+      </arguments>
+    </mpirun>
+
+    <module_system type="none"/>
+
+    <environment_variables>
+      <env name="OMP_STACKSIZE">128M</env>
+      <env name="FI_CXI_RX_MATCH_MODE">hybrid</env>
+    </environment_variables>
+    <environment_variables comp_interface="nuopc">
+      <!-- required on all systems for timing file output --> 
+      <env name="ESMF_RUNTIME_PROFILE">ON</env>
+      <env name="ESMF_RUNTIME_PROFILE_OUTPUT">SUMMARY</env>
+    </environment_variables>
+  </machine>

--- a/recipes/esmf/26.07/extra/esmf/machines/eiger/gnu_eiger.cmake
+++ b/recipes/esmf/26.07/extra/esmf/machines/eiger/gnu_eiger.cmake
@@ -1,0 +1,9 @@
+# work around strict compiler warnings in gfortran 10 and later
+string(APPEND FFLAGS " -fallow-argument-mismatch -fallow-invalid-boz")
+if (compile_threaded)
+  string(APPEND FFLAGS " -qopenmp")
+endif()
+
+# help CESM find lapack
+string(APPEND SLIBS " -L/user-environment/env/esmf/lib -lopenblas")
+

--- a/recipes/esmf/26.07/extra/reframe.yaml
+++ b/recipes/esmf/26.07/extra/reframe.yaml
@@ -1,0 +1,12 @@
+default:
+  features:
+    - mpi
+    - openmp
+    - osu-micro-benchmarks
+    - prgenv
+    - serial
+  cc: mpicc
+  cxx: mpic++
+  ftn: mpifort
+  views:
+    - esmf


### PR DESCRIPTION
The current esmf image includes all specs in the environment, which causes srun to get heartburn.

This version carefully includes all required runtime specs as root specs, to provide the cleanest possible environment that works.

This has been built and deployed to

```
service::esmf/26.07:rc1@eiger
```