### PR TITLE
paraview/6.1:v2

### DIFF
--- a/recipes/paraview/6.1/gh200/packages.yaml
+++ b/recipes/paraview/6.1/gh200/packages.yaml
@@ -16,6 +16,9 @@ packages:
       - +hdf5
       # note: https://github.com/llnl/conduit/issues/1582
       - "@git.df1394ba1d6a3bfba467a60ee0e1ea3d87a8eb53=0.9.6"
+  ospray:
+    require:
+      - "@3.1"
   gl:
     require: egl
   llvm:

--- a/recipes/paraview/6.1/zen2/packages.yaml
+++ b/recipes/paraview/6.1/zen2/packages.yaml
@@ -13,6 +13,9 @@ packages:
       - +hdf5
       # note: https://github.com/llnl/conduit/issues/1582
       - "@git.df1394ba1d6a3bfba467a60ee0e1ea3d87a8eb53=0.9.6"
+  ospray:
+    require:
+      - "@3.1"
   gl:
     require: osmesa
   llvm:


### PR DESCRIPTION
This release is mainly for downgrading to `ospray@3.1` because in `ospray@3.2` there seems to be a bug with color rendering.

The rest of the image is roughly unchanged, apart from the network stack that in the meanwhile has undergone some changes (mainly https://github.com/eth-cscs/alps-cluster-config/pull/88 and https://github.com/eth-cscs/alps-cluster-config/commit/7bfb559a5f3c9baa3d48b453ca255dffa102c844)