### PR TITLE
prgenv-gnu 26.9 for eiger

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -362,6 +362,11 @@ uenvs:
         santis: [gh200]
         bristen: [a100]
         eiger: [zen2]
+    "26.9":
+      recipes:
+        zen2: 26.9/mc
+      deploy:
+        eiger: [zen2]
   prgenv-gnu-openmpi:
     "25.12":
       recipes:

--- a/recipes/prgenv-gnu/26.9/mc/compilers.yaml
+++ b/recipes/prgenv-gnu/26.9/mc/compilers.yaml
@@ -1,0 +1,2 @@
+gcc:
+  version: "14"

--- a/recipes/prgenv-gnu/26.9/mc/config.yaml
+++ b/recipes/prgenv-gnu/26.9/mc/config.yaml
@@ -1,0 +1,10 @@
+name: prgenv-gnu
+spack:
+  repo: https://github.com/spack/spack.git
+  commit: v1.2
+  packages:
+    repo: https://github.com/spack/spack-packages.git
+    commit: 865ed861e7d36c4c909c570d9439c2a18431c0b1 # Sept 03
+store: /user-environment
+description: GNU Compiler toolchain with cray-mpich, Python, CMake and other development tools.
+version: 2

--- a/recipes/prgenv-gnu/26.9/mc/config.yaml
+++ b/recipes/prgenv-gnu/26.9/mc/config.yaml
@@ -1,7 +1,7 @@
 name: prgenv-gnu
 spack:
   repo: https://github.com/spack/spack.git
-  commit: v1.2
+  commit: v1.2.2
   packages:
     repo: https://github.com/spack/spack-packages.git
     commit: 865ed861e7d36c4c909c570d9439c2a18431c0b1 # Sept 03

--- a/recipes/prgenv-gnu/26.9/mc/environments.yaml
+++ b/recipes/prgenv-gnu/26.9/mc/environments.yaml
@@ -1,0 +1,40 @@
+gcc-env:
+  compiler: [gcc]
+  network:
+      mpi: cray-mpich@9.1.0
+  unify: true
+  specs:
+  - boost +chrono +filesystem +iostreams +mpi +program_options +python +regex +serialization +shared +system +timer
+  - cmake
+  - fftw
+  - fmt
+  - gmp
+  - gsl
+  - hdf5+cxx+hl+fortran
+  - kokkos +aggressive_vectorization cxxstd=17 +openmp +pic +serial +shared +tuning
+  - kokkos-kernels +blas +execspace_openmp +execspace_serial +lapack +openmp scalars=float,double,complex_float,complex_double +serial +shared +superlu
+  - kokkos-tools +mpi +papi
+  - netlib-scalapack
+  - lua
+  - libtree
+  - lz4
+  - meson
+  - netcdf-c build_system=cmake
+  - netcdf-cxx
+  - netcdf-cxx4
+  - netcdf-fortran
+  - ninja
+  - openblas threads=openmp
+  - osu-micro-benchmarks
+  - python
+  - superlu
+  - zlib-ng
+  variants:
+  - +mpi
+  views:
+    default:
+      link: roots
+      uenv:
+        add_compilers: true
+        prefix_paths:
+          LD_LIBRARY_PATH: [lib, lib64]

--- a/recipes/prgenv-gnu/26.9/mc/extra/reframe.yaml
+++ b/recipes/prgenv-gnu/26.9/mc/extra/reframe.yaml
@@ -1,0 +1,13 @@
+default:
+  features:
+    - mpi
+    - cray-mpich
+    - openmp
+    - osu-micro-benchmarks
+    - prgenv
+    - serial
+  cc: mpicc
+  cxx: mpic++
+  ftn: mpifort
+  views:
+    - default

--- a/recipes/prgenv-gnu/26.9/mc/modules.yaml
+++ b/recipes/prgenv-gnu/26.9/mc/modules.yaml
@@ -1,0 +1,23 @@
+modules:
+  # Paths to check when creating modules for all module sets
+  prefix_inspections:
+    bin:
+      - PATH
+    lib:
+      - LD_LIBRARY_PATH
+    lib64:
+      - LD_LIBRARY_PATH
+
+  default:
+    arch_folder: false
+    # Where to install modules
+    roots:
+      tcl: /user-environment/modules
+    tcl:
+      all:
+        autoload: none
+      hash_length: 0
+      exclude_implicits: true
+      exclude: []
+      projections:
+        all: '{name}/{version}'


### PR DESCRIPTION
- update cray-mpich to `9.1.0`
- rebuild for current glibc (2.38)

`prgenv-gnu/26.3@eiger` cannot be used as spack upstream currently, because it was built for an older glibc (cray-mpich etc will get re-concretized)

Note: `prgenv-gnu/26.3@daint` has `cray-mpich@9.1.0` already (and also current glibc)